### PR TITLE
Bug fix: paged store deletes toasted fields on record delete.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,7 +42,7 @@
                     'MACOSX_DEPLOYMENT_TARGET': '10.7',
                     'GCC_ENABLE_CPP_RTTI': 'YES',
                     'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-                    'OTHER_CFLAGS': [ '-std=c++11', '-stdlib=libc++' ]
+                    'OTHER_CFLAGS': [ '-std=c++11', '-stdlib=libc++', '-Wno-deprecated-declarations', '-Wno-deprecated-copy-with-user-provided-copy', '-Wno-null-dereference', '-Wno-unused-but-set-variable' ]
                 },
             }],
         ],
@@ -113,10 +113,27 @@
     'targets': [
         {
             # unit tests module
+            'target_name': 'glib-base-test',
+            'type': 'executable',
+            'sources': [
+                'test/cpp/test_main.cpp',
+                'test/cpp/test_blobbs.cpp',
+                'test/cpp/test_pgblob.cpp'
+            ],
+            'include_dirs': [
+                'src/glib/base'
+            ],
+            'dependencies': [
+                'glib'
+            ]
+        },
+        {
+            # unit tests module
             'target_name': 'qminer-test',
             'type': 'executable',
             'sources': [
                 'test/cpp/test_main.cpp',
+                'test/cpp/test_storage.cpp',
                 'test/cpp/test_linalg.cpp',
                 'test/cpp/test_misc.cpp',
                 'test/cpp/test_quantiles.cpp',

--- a/src/glib/base/blobbs.cpp
+++ b/src/glib/base/blobbs.cpp
@@ -13,7 +13,7 @@ TStr TBlobPt::GetStr() const {
     ChA+='[';
     if (Empty()) {
         ChA+="Null";
-    } 
+    }
     else {
         ChA+=TUInt::GetStr(uint(Seg)); ChA+=':'; ChA+=TUInt::GetStr(Addr);
     }
@@ -82,7 +82,7 @@ void TBlobBsUsageStats::PrintStats()
 {
     TNotify::StdNotify->OnStatusFmt("Total used: %.1fMB", TotalUsed / TInt::Mega);
     TNotify::StdNotify->OnStatusFmt("Total free: %.1fMB", TotalFree / TInt::Mega);
-    
+
     TNotify::StdNotify->OnStatus("Used blocks per size:");
     TUIntV KeyV; UsedBlockSizeToCntH.GetKeyV(KeyV);
     KeyV.Sort();
@@ -101,7 +101,7 @@ void TBlobBsUsageStats::PrintStats()
 /////////////////////////////////////////////////
 // Blob-Base
 const int TBlobBs::MnBlobBfL=16;
-const int TBlobBs::MxBlobFLen=2000000000;
+const int TBlobBs::MxBlobFLen=2000000000; // 2G
 
 void TBlobBs::PutVersionStr(const PFRnd& File){
   File->PutStr(GetVersionStr());
@@ -222,7 +222,7 @@ void TBlobBs::GetAllocInfo(const int& BfL, const TIntV& BlockLenV, int& MxBfL, i
     }
     EAssert(BlockLenN<BlockLenV.Len());
     // se the return info for the available size and index
-    MxBfL = BlockLenV[BlockLenN]; 
+    MxBfL = BlockLenV[BlockLenN];
     FFreeBlobPtN = BlockLenN;
 }
 
@@ -297,7 +297,7 @@ TGBlobBs::TGBlobBs(const TStr& BlobBsFNm, const TFAccess& _Access, const int& _M
         // initialize and save the vector of pointers to free blobs
         GenFFreeBlobPtV(BlockLenV, FFreeBlobPtV);
         PutFFreeBlobPtV(File, FFreeBlobPtV);
-    } 
+    }
     else {
         File->SetFPos(0);
         AssertVersionStr(File);
@@ -358,7 +358,7 @@ TBlobPt TGBlobBs::PutBlob(const PSIn& SIn){
             File->PutCh(TCh::NullCh, MxBfL-BfL);
             File->PutCs(Cs);
             PutBlobTag(File, btEnd);
-            
+
 	        Stats.AllocCount++;
 	        Stats.AllocSize += MxBfL;
 	        Stats.AllocUnusedSize += (MxBfL - BfL);
@@ -377,7 +377,7 @@ TBlobPt TGBlobBs::PutBlob(const PSIn& SIn){
         // make sure the block is really free
         AssertBlobState(File, bsFree);
         // deleted blocks are saved as "linked list" - the address of the next free block is stored in the content of next 4 bytes
-        FFreeBlobPtV[FFreeBlobPtN] = TBlobPt::LoadAddr(File); 
+        FFreeBlobPtV[FFreeBlobPtN] = TBlobPt::LoadAddr(File);
         // move the file location back to the place where we start writing the data and save the data
         File->SetFPos(FPos);
         PutBlobState(File, bsActive);
@@ -415,7 +415,7 @@ TBlobPt TGBlobBs::PutBlob(const TBlobPt& BlobPt, const PSIn& SIn, int& ReleasedS
         // that we have space available to fill
         ReleasedSize = DelBlob(BlobPt);
         return PutBlob(SIn);
-    } 
+    }
     else {
         // we are not releasing any data chunk
         ReleasedSize = -1;
@@ -500,7 +500,7 @@ bool TGBlobBs::FNextBlobPt(TBlobPt& TrvBlobPt, TBlobPt& BlobPt, PSIn& BlobSIn){
         if (TrvBlobAddr>=uint(File->GetFLen())) {
             TrvBlobPt.Clr(); BlobPt.Clr(); BlobSIn=NULL;
             return false;
-        } 
+        }
         else {
             File->SetFPos(TrvBlobAddr);
             AssertBlobTag(File, btBegin);
@@ -509,7 +509,7 @@ bool TGBlobBs::FNextBlobPt(TBlobPt& TrvBlobPt, TBlobPt& BlobPt, PSIn& BlobSIn){
             switch (BlobState){
                 case bsActive:{
                     const int BfL = File->GetInt();
-                    TCs BfCs; 
+                    TCs BfCs;
                     BlobSIn = File->GetSIn(BfL, BfCs);
                     File->MoveFPos(MxBfL-BfL);
                     const TCs FCs=File->GetCs();
@@ -523,8 +523,8 @@ bool TGBlobBs::FNextBlobPt(TBlobPt& TrvBlobPt, TBlobPt& BlobPt, PSIn& BlobSIn){
                     AssertBlobTag(File, btEnd);
                     TrvBlobPt=TBlobPt(File->GetFPos());
                     break;
-                default: 
-                    Fail; 
+                default:
+                    Fail;
                     return false;
             }
         }
@@ -540,7 +540,7 @@ void TGBlobBs::ComputeUsageStats(TBlobBsUsageStats& UsageStats)
 {
     TBlobPt BlobPt = GetFirstBlobPt();
     uint Addr = BlobPt.GetAddr();
-    const uint FLen = (uint) File->GetFLen(); 
+    const uint FLen = (uint) File->GetFLen();
     while (Addr < FLen) {
         File->SetFPos(Addr);
         AssertBlobTag(File, btBegin);
@@ -591,8 +591,8 @@ void TMBlobBs::SaveMain() const {
 
 TMBlobBs::TMBlobBs(const TStr& BlobBsFNm, const TFAccess& _Access, const int& _MxSegLen):
     TBlobBs(), Access(_Access), MxSegLen(_MxSegLen), NrFPath(), NrFMid(), SegV() {
-    if (MxSegLen == -1){ 
-        MxSegLen=MxBlobFLen; 
+    if (MxSegLen == -1){
+        MxSegLen=MxBlobFLen;
     }
     // initialize the hashtable of block sizes to first segment
     TBlobBs::GenBlockLenV(BlockLenV);
@@ -606,7 +606,7 @@ TMBlobBs::TMBlobBs(const TStr& BlobBsFNm, const TFAccess& _Access, const int& _M
             TStr SegFNm=GetSegFNm(NrFPath, NrFMid, 0);
             PBlobBs Seg=TGBlobBs::New(SegFNm, faCreate, MxSegLen);
             SegV.Add(Seg);
-            SaveMain(); 
+            SaveMain();
             break; }
         case faUpdate:
         case faRdOnly:{
@@ -714,7 +714,7 @@ TBlobPt TMBlobBs::PutBlob(const TBlobPt& BlobPt, const PSIn& SIn, int& ReleasedS
         // we were not able to save the data in the current segment so we want to store it as a new blob
         // the data in the old blob was already removed
         NewBlobPt = PutBlob(SIn);
-    } 
+    }
     else {
         // remember in which segment we put the blob
         NewBlobPt.PutSeg(BlobPt.GetSeg());
@@ -764,7 +764,7 @@ bool TMBlobBs::FNextBlobPt(TBlobPt& TrvBlobPt, TBlobPt& BlobPt, PSIn& BlobSIn){
 }
 
 bool TMBlobBs::Exists(const TStr& BlobBsFNm){
-    TStr NrFPath; TStr NrFMid; 
+    TStr NrFPath; TStr NrFMid;
     GetNrFPathFMid(BlobBsFNm, NrFPath, NrFMid);
     const TStr MainFNm = GetMainFNm(NrFPath, NrFMid);
     return TFile::Exists(MainFNm);

--- a/src/glib/base/fl.cpp
+++ b/src/glib/base/fl.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -64,7 +64,7 @@ bool TSIn::GetNextLn(TChA& LnChA){
 }
 
 TStr TSIn::GetSNm() const {
-  return "Input-Stream"; 
+  return "Input-Stream";
 }
 
 const PSIn TSIn::StdIn=PSIn(new TStdIn());
@@ -150,7 +150,7 @@ int TSOut::PutStrFmt(const char *FmtStr, ...){
   va_start(valist, FmtStr);
   const int RetVal=vsnprintf(Bf, 10*1024-2, FmtStr, valist);
   va_end(valist);
-  return RetVal!=-1 ? PutStr(TStr(Bf)) : 0;	
+  return RetVal!=-1 ? PutStr(TStr(Bf)) : 0;
 }
 
 int TSOut::PutStrFmtLn(const char *FmtStr, ...){
@@ -159,7 +159,7 @@ int TSOut::PutStrFmtLn(const char *FmtStr, ...){
   va_start(valist, FmtStr);
   const int RetVal=vsnprintf(Bf, 10*1024-2, FmtStr, valist);
   va_end(valist);
-  return RetVal!=-1 ? PutStrLn(TStr(Bf)) : PutLn();	
+  return RetVal!=-1 ? PutStrLn(TStr(Bf)) : PutLn();
 }
 
 int TSOut::PutIndent(const int& IndentLev){
@@ -220,7 +220,7 @@ TSOut& TSOut::operator<<(TSIn& SIn) {
 }
 
 TStr TSOut::GetSNm() const {
-  return "Output-Stream"; 
+  return "Output-Stream";
 }
 
 const PSOut TSOut::StdOut=PSOut(new TStdOut());
@@ -228,14 +228,14 @@ const PSOut TSOut::StdOut=PSOut(new TStdOut());
 TStdOut::TStdOut(): TSBase(), TSOut(){}
 
 TStr TStdOut::GetSNm() const {
-  return "Standard output"; 
+  return "Standard output";
 }
 
 /////////////////////////////////////////////////
 // Input-Output-Stream-Base
 
 TStr TSInOut::GetSNm() const {
-  return "Input-Output-Stream"; 
+  return "Input-Output-Stream";
 }
 
 /////////////////////////////////////////////////
@@ -396,7 +396,7 @@ bool TFIn::GetNextLnBf(TChA& LnChA) {
   // eof or the last line has no newline
   return !LnChA.Empty();
 }
-    
+
 // Sets BfN to the end of line or end of buffer. Reads more data, if needed.
 // Returns 1, when an end of line was found, BfN is end of line.
 // Returns 0, when an end of line was not found and more data is required,
@@ -443,7 +443,7 @@ int TFIn::FindEol(int& BfN, bool& CrEnd) {
 }
 
 TStr TFIn::GetSNm() const {
-  return SNm; 
+  return SNm;
 }
 
 /////////////////////////////////////////////////
@@ -521,7 +521,7 @@ void TFOut::Flush(){
 }
 
 TStr TFOut::GetSNm() const {
-  return SNm; 
+  return SNm;
 }
 
 /////////////////////////////////////////////////
@@ -663,7 +663,7 @@ bool TMIn::GetNextLnBf(TChA& LnChA){
 }
 
 TStr TMIn::GetSNm() const {
-  return "Input-Memory"; 
+  return "Input-Memory";
 }
 
 /////////////////////////////////////////////////
@@ -671,12 +671,12 @@ TStr TMIn::GetSNm() const {
 void TMOut::Resize(const int& ReqLen){
   IAssert(OwnBf&&(BfL==MxBfL || ReqLen >= 0));
   if (Bf==NULL){
-    IAssert(MxBfL==0); 
+    IAssert(MxBfL==0);
     if (ReqLen < 0) Bf=new char[MxBfL=1024];
     else Bf=new char[MxBfL=ReqLen];
   } else {
     if (ReqLen < 0){ MxBfL*=2; }
-    else if (ReqLen < MxBfL){ return; } // nothing to do 
+    else if (ReqLen < MxBfL){ return; } // nothing to do
     else { MxBfL=(2*MxBfL < ReqLen ? ReqLen : 2*MxBfL); }
     char* NewBf=new char[MxBfL];
     memmove(NewBf, Bf, BfL); delete[] Bf; Bf=NewBf;
@@ -796,7 +796,7 @@ void TMOut::MkEolnLn(){
 }
 
 TStr TMOut::GetSNm() const {
-  return "Output-Memory"; 
+  return "Output-Memory";
 }
 
 /////////////////////////////////////////////////
@@ -1012,13 +1012,13 @@ bool TFile::Exists(const TStr& FNm){
 
 #if defined(GLib_WIN)
 
-void TFile::Copy(const TStr& SrcFNm, const TStr& DstFNm, 
+void TFile::Copy(const TStr& SrcFNm, const TStr& DstFNm,
  const bool& ThrowExceptP, const bool& FailIfExistsP){
   if (ThrowExceptP){
     if (CopyFile(SrcFNm.CStr(), DstFNm.CStr(), FailIfExistsP) == 0) {
         int ErrorCode = (int)GetLastError();
         TExcept::Throw(TStr::Fmt(
-            "Error %d copying file '%s' to '%s'.", 
+            "Error %d copying file '%s' to '%s'.",
             ErrorCode, SrcFNm.CStr(), DstFNm.CStr()));
     }
   } else {
@@ -1110,7 +1110,7 @@ bool TFile::Move(const TStr& SrcFNm, const TStr& DstFNm,
 
 void TFile::Copy(const TStr& SrcFNm, const TStr& DstFNm,
   const bool& ThrowExceptP, const bool& FailIfExistsP) {
-    
+
     FailR("Feature not implemented");
 }
 
@@ -1170,7 +1170,7 @@ TStr TFile::GetUniqueFNm(const TStr& FNm){
 #ifdef GLib_WIN
 
 uint64 TFile::GetSize(const TStr& FNm) {
-    // open 
+    // open
     HANDLE hFile = CreateFile(
        FNm.CStr(),            // file to open
        GENERIC_READ,          // open for reading
@@ -1193,7 +1193,7 @@ uint64 TFile::GetSize(const TStr& FNm) {
 }
 
 uint64 TFile::GetCreateTm(const TStr& FNm) {
-    // open 
+    // open
     HANDLE hFile = CreateFile(
        FNm.CStr(),            // file to open
        GENERIC_READ,          // open for reading
@@ -1212,13 +1212,13 @@ uint64 TFile::GetCreateTm(const TStr& FNm) {
     // close file
     CloseHandle(hFile);
     // convert to uint64
-    TUInt64 UInt64(uint(lpCreationTime.dwHighDateTime), 
+    TUInt64 UInt64(uint(lpCreationTime.dwHighDateTime),
         uint(lpCreationTime.dwLowDateTime));
     return UInt64.Val / uint64(10000);
 }
 
 uint64 TFile::GetLastAccessTm(const TStr& FNm) {
-    // open 
+    // open
     HANDLE hFile = CreateFile(
        FNm.CStr(),            // file to open
        GENERIC_READ,          // open for reading
@@ -1237,13 +1237,13 @@ uint64 TFile::GetLastAccessTm(const TStr& FNm) {
     // close file
     CloseHandle(hFile);
     // convert to uint64
-    TUInt64 UInt64(uint(lpLastAccessTime.dwHighDateTime), 
+    TUInt64 UInt64(uint(lpLastAccessTime.dwHighDateTime),
         uint(lpLastAccessTime.dwLowDateTime));
     return UInt64.Val / uint64(10000);
 }
 
 uint64 TFile::GetLastWriteTm(const TStr& FNm) {
-    // open 
+    // open
     HANDLE hFile = CreateFile(
        FNm.CStr(),            // file to open
        GENERIC_READ,          // open for reading
@@ -1262,7 +1262,7 @@ uint64 TFile::GetLastWriteTm(const TStr& FNm) {
     // close file
     CloseHandle(hFile);
     // convert to uint64
-    TUInt64 UInt64(uint(lpLastWriteTime.dwHighDateTime), 
+    TUInt64 UInt64(uint(lpLastWriteTime.dwHighDateTime),
         uint(lpLastWriteTime.dwLowDateTime));
     return UInt64.Val / uint64(10000);
 }
@@ -1272,7 +1272,7 @@ uint64 TFile::GetLastWriteTm(const TStr& FNm) {
 uint64 TFile::GetSize(const TStr& FNm) {
     struct stat st;
     stat(FNm.CStr(), &st);
-    return (uint64)st.st_size;    
+    return (uint64)st.st_size;
 }
 
 uint64 TFile::GetCreateTm(const TStr& FNm) {

--- a/src/glib/base/http.cpp
+++ b/src/glib/base/http.cpp
@@ -181,7 +181,7 @@ typedef enum {
   heBadSearchStr} THttpExCd;
 
 class THttpEx{
-private:
+protected:
   THttpExCd HttpExCd;
 public:
   THttpEx(const THttpExCd& _HttpExCd): HttpExCd(_HttpExCd){}

--- a/src/glib/base/pgblob.h
+++ b/src/glib/base/pgblob.h
@@ -137,6 +137,8 @@ public:
     int GetPrimHashCd() const;
     /// for insertion into THash
     int GetSecHashCd() const;
+
+    TStr GetStr() const { return TStr::Fmt("%d:%d:%d", FileIndex, Page, ItemIndex); }
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -275,7 +277,7 @@ private:
 
 protected:
     /// Housekeeping record for each loaded page
-    struct LoadedPage {
+    struct TLoadedPage {
     public:
         /// Blob pointer of this page
         TPgBlobPgPt Pt;
@@ -345,7 +347,7 @@ protected:
     /// Pointers for loaded pages
     THash<TPgBlobPgPt, int> LoadedPagesH;
     /// Pointers for loaded pages
-    TVec<LoadedPage> LoadedPages;
+    TVec<TLoadedPage> LoadedPages;
     /// Heap structure that keeps track of free space in pages
     TPgBlobFsm Fsm;
 

--- a/src/glib/base/shash.h
+++ b/src/glib/base/shash.h
@@ -58,7 +58,7 @@ public:
     TInt ElemCnt(SIn);  const int Start=clock();
     if (ElemCnt < LoadN || LoadN == -1) { LoadN = ElemCnt; }
     printf("Loading %s: %d elements ... ", SIn.GetSNm().CStr(), LoadN);  DatV.Gen(LoadN, 0);
-    for (int i = 0; i < LoadN; i++) { TKey(SIn);  DatV.Add(TDat(SIn)); }
+    for (int i = 0; i < LoadN; i++) { TKey Key(SIn);  DatV.Add(TDat(SIn)); }
     printf(" [%ds]\n", int((clock()-Start)/CLOCKS_PER_SEC));
   }
 };

--- a/src/glib/base/ss.cpp
+++ b/src/glib/base/ss.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -237,7 +237,7 @@ void TSs::LoadTxtFldV(
  const TSsFmt& SsFmt, const PSIn& SIn, char& Ch,
  TStrV& FldValV, const bool& IsExcelEoln, const bool& IsQStr){
   if (!SIn->Eof()){
-    FldValV.Clr(false); int X=0;
+    FldValV.Clr(false);
     if (Ch==TCh::NullCh){Ch=SIn->GetCh();}
     TChA ChA;
     while (!SIn->Eof()){
@@ -293,16 +293,16 @@ void TSs::LoadTxtFldV(
         break;
       } else
       if ((SsFmt==ssfTabSep)&&(Ch=='\t')){
-        X++; Ch=SIn->GetCh();
+        Ch=SIn->GetCh();
       } else
       if ((SsFmt==ssfCommaSep)&&(Ch==',')){
-        X++; Ch=SIn->GetCh();
+        Ch=SIn->GetCh();
       } else
       if ((SsFmt==ssfSemicolonSep)&&(Ch==';')){
-        X++; Ch=SIn->GetCh();
+        Ch=SIn->GetCh();
       } else
       if ((SsFmt==ssfVBar)&&(Ch=='|')){
-        X++; Ch=SIn->GetCh();
+        Ch=SIn->GetCh();
       } else
       if (Ch=='\r'){
         Ch=SIn->GetCh();
@@ -310,7 +310,7 @@ void TSs::LoadTxtFldV(
         break;
       } else
       if (Ch=='\n'){
-        X=0; Ch=SIn->GetCh();
+        Ch=SIn->GetCh();
         if ((Ch=='\r')&&(!SIn->Eof())){Ch=SIn->GetCh();}
         break;
       } else {
@@ -358,7 +358,7 @@ TStr TSs::GetSsFmtNmVStr(){
 // Fast-Spread-Sheet-Parser
 const char TSsParser::QUOTE_CH = '"';
 
-TSsParser::TSsParser(const TStr& FNm, const TSsFmt _SsFmt, const bool& _SkipLeadBlanks, const bool& _SkipCmt, const bool& _SkipEmptyFld) : SsFmt(_SsFmt), 
+TSsParser::TSsParser(const TStr& FNm, const TSsFmt _SsFmt, const bool& _SkipLeadBlanks, const bool& _SkipCmt, const bool& _SkipEmptyFld) : SsFmt(_SsFmt),
  SkipLeadBlanks(_SkipLeadBlanks), SkipCmt(_SkipCmt), SkipEmptyFld(_SkipEmptyFld), LineCnt(0), /*Bf(NULL),*/ SplitCh('\t'), LineStr(), FldV(), FInPt(NULL) {
   if (TZipIn::IsZipExt(FNm.GetFExt())) { FInPt = TZipIn::New(FNm); }
   else { FInPt = TFIn::New(FNm); }
@@ -408,7 +408,7 @@ bool TSsParser::NextSlow() { // split on SplitCh
   }
   char *last = cur;
   while (*cur) {
-    if (SsFmt == ssfWhiteSep) { while (*cur && ! TCh::IsWs(*cur)) { cur++; } } 
+    if (SsFmt == ssfWhiteSep) { while (*cur && ! TCh::IsWs(*cur)) { cur++; } }
     else {
     	while (*cur) {
 			if (*cur == QUOTE_CH) {
@@ -431,7 +431,7 @@ bool TSsParser::NextSlow() { // split on SplitCh
   }
   FldV.Add(last);  // add last field
   if (SkipEmptyFld && FldV.Empty()) { return NextSlow(); } // skip empty lines
-  return true; 
+  return true;
 }
 
 // Gets and parses the next line, quick version, works with buffers, not chars.
@@ -450,7 +450,7 @@ bool TSsParser::Next() { // split on SplitCh
   }
   char *last = cur;
   while (*cur) {
-    if (SsFmt == ssfWhiteSep) { while (*cur && ! TCh::IsWs(*cur)) { cur++; } } 
+    if (SsFmt == ssfWhiteSep) { while (*cur && ! TCh::IsWs(*cur)) { cur++; } }
     else {
     	while (*cur) {
 			if (*cur == QUOTE_CH) {
@@ -473,7 +473,7 @@ bool TSsParser::Next() { // split on SplitCh
   }
   FldV.Add(last);  // add last field
   if (SkipEmptyFld && FldV.Empty()) { return Next(); } // skip empty lines
-  return true; 
+  return true;
 }
 
 void TSsParser::ToLc() {
@@ -492,9 +492,9 @@ bool TSsParser::GetInt(const int& FldN, int& Val) const {
   if (*c=='-') { Minus=true; c++; }
   if (! TCh::IsNum(*c)) { return false; }
   _Val = TCh::GetNum(*c);  c++;
-  while (TCh::IsNum(*c)){ 
-    _Val = 10 * _Val + TCh::GetNum(*c); 
-    c++; 
+  while (TCh::IsNum(*c)){
+    _Val = 10 * _Val + TCh::GetNum(*c);
+    c++;
   }
   if (Minus) { _Val = -_Val; }
   if (*c != 0) { return false; }

--- a/src/glib/mine/bowbs.cpp
+++ b/src/glib/mine/bowbs.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -452,7 +452,7 @@ double TBowSim::GetCosSim(const PBowSpV& SpV1, const PBowSpV& SpV2) {
   int WIds1=SpV1->GetWIds();
   int WIds2=SpV2->GetWIds();
   // search for equal words in both documents
-  double WordWgtProdSum=0; int IntsWords=0;
+  double WordWgtProdSum=0;
   int WIdN1=0; int WIdN2=0;
   while ((WIdN1<WIds1)&&(WIdN2<WIds2)){
     int WId1=SpV1->GetWId(WIdN1);
@@ -467,7 +467,7 @@ double TBowSim::GetCosSim(const PBowSpV& SpV1, const PBowSpV& SpV2) {
       double WordWgt1=SpV1->GetWgt(WIdN1); WIdN1++;
       double WordWgt2=SpV2->GetWgt(WIdN2); WIdN2++;
       double WordWgtProd=WordWgt1*WordWgt2;
-      WordWgtProdSum+=WordWgtProd; IntsWords++;
+      WordWgtProdSum+=WordWgtProd;
     } else {
       WIdN1++;
     }
@@ -490,7 +490,7 @@ double TBowSim::GetCosSim(
   int WIds1=SpV1->GetWIds();
   int WIds2=SpV2->GetWIds();
   // search for equal words in both documents
-  double WordWgtProdSum=0; int IntsWords=0;
+  double WordWgtProdSum=0;
   int WIdN1=0; int WIdN2=0; WgtWIdPrV.Clr();
   while ((WIdN1<WIds1)&&(WIdN2<WIds2)){
     int WId1=SpV1->GetWId(WIdN1);
@@ -505,7 +505,7 @@ double TBowSim::GetCosSim(
       double WordWgt1=SpV1->GetWgt(WIdN1); WIdN1++;
       double WordWgt2=SpV2->GetWgt(WIdN2); WIdN2++;
       double WordWgtProd=WordWgt1*WordWgt2;
-      WordWgtProdSum+=WordWgtProd; IntsWords++;
+      WordWgtProdSum+=WordWgtProd;
       WgtWIdPrV.Add(TFltIntPr(WordWgtProd, WId1));
     } else {
       WIdN1++;
@@ -781,7 +781,7 @@ PBowDocWgtBs TBowDocWgtBs::New(const TVec<PBowSpV>& BowSpVV) {
         AllWords = TInt::GetMx(AllWords, BowSpVV[DocN]->GetLastWId()+1);
     }
     // load documents
-    DocWgtBs->WordFqV.Gen(AllWords); 
+    DocWgtBs->WordFqV.Gen(AllWords);
     DocWgtBs->WordFqV.PutAll(0.0);
     DocWgtBs->DocSpVV = BowSpVV;
     // return result
@@ -1407,11 +1407,11 @@ void TBowDocBs::DelDoc(const TStr& DocNm) {
 	int DId=-1;
 	if (!DocNmToDescStrH.IsKey(DocNm, DId))
 		return;
-	
+
 	// remove the categories for the document
 	DocCIdVV[DId].Clr();
 	PBowSpV DocSpV=DocSpVV[DId];
-  
+
 	// decrease the document frequency for the words
 	for (int WIdN = 0; WIdN < DocSpV->GetWIds(); WIdN++) {
 		int WId = DocSpV->GetWId(WIdN);
@@ -1445,7 +1445,7 @@ int TBowDocBs::AppendDoc(const TStr& _DocNm, const TStrV& CatNmV, const TStrV& W
 	TStrIntH DocWordStrToFqH;
 	for (int WordStrN=0; WordStrN<WordStrV.Len(); WordStrN++)
 		DocWordStrToFqH.AddDat(WordStrV[WordStrN])++;
-	
+
 	// compose document bag-of-words vector
 	PBowSpV DocSpV=DocSpVV[DId];
 	for (int DocWordStrN=0; DocWordStrN<DocWordStrToFqH.Len(); DocWordStrN++) {
@@ -1517,7 +1517,7 @@ void TBowDocBs::AppendWord(const int DId, const TStr& Word, const float Wgt) {
 		DocSpV->AddWIdWgt(WId, Wgt);			// for new WIds add them to the vector
 }
 
-/// create a new BowDocBs where a document i is created by merging the vector of documents DIdVV[i]. 
+/// create a new BowDocBs where a document i is created by merging the vector of documents DIdVV[i].
 // The name of the document i is DocNmV[i]
 // NOTE: Categories are ignored
 PBowDocBs TBowDocBs::GetMergedDocs(const TVec<TIntV>& DIdVV, const TStrV& DocNmV) const {
@@ -1525,7 +1525,7 @@ PBowDocBs TBowDocBs::GetMergedDocs(const TVec<TIntV>& DIdVV, const TStrV& DocNmV
 	PBowDocBs BowDocBs=TBowDocBs::New();
 	BowDocBs->DocSpVV.Gen(DIdVV.Len(), 0);
 	BowDocBs->DocCIdVV.Gen(DIdVV.Len(), 0);
-	
+
 	// copy the hash with mapping of words to ids
 	for (int N=0; N < GetWords(); N++)
 		BowDocBs->AddWordStr(GetWordStr(N));
@@ -1938,7 +1938,7 @@ PBowSpV TBowDocBs::GetSpVFromHtmlStr(
   return DocSpV;
 }
 
-PBowSpV TBowDocBs::GetSpVFromHtmlStr(const TStr& HtmlStr, 
+PBowSpV TBowDocBs::GetSpVFromHtmlStr(const TStr& HtmlStr,
         const int& Docs, const TFltV& WordFqV) const {
 
     // get word-list

--- a/src/glib/mine/bowclust.cpp
+++ b/src/glib/mine/bowclust.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -610,17 +610,17 @@ void TBowDocPart::SaveXml(
 }
 
 //B:
-void TBowDocPart::SaveRdfClusts(const PSOut& SOut, const PBowDocBs& BowDocBs, 
+void TBowDocPart::SaveRdfClusts(const PSOut& SOut, const PBowDocBs& BowDocBs,
         TIntIntVH& DIdClustIdVH, const int& FatherId, int& ClustId) const {
 
     for (int ClustN=0; ClustN<GetClusts(); ClustN++) {
         PBowDocPartClust Clust=GetClust(ClustN);
         TStr CptNm, KeyWdStr;
-        
+
         if (!Clust->GetNm().Empty()){
             CptNm = Clust->GetNm(); }
         if (Clust->IsConceptSpV()) {
-            KeyWdStr = Clust->GetConceptSpV()->GetStr(BowDocBs, 20); 
+            KeyWdStr = Clust->GetConceptSpV()->GetStr(BowDocBs, 20);
             if (CptNm.Empty()) {
                 CptNm = Clust->GetConceptSpV()->GetStr(BowDocBs, 5, 1, ", ", false); }
         }
@@ -666,7 +666,7 @@ void TBowDocPart::SaveRdfClusts(const PSOut& SOut, const PBowDocBs& BowDocBs,
 //B:
 void TBowDocPart::SaveRdf(const TStr& FNm, const PBowDocBs& BowDocBs) const {
     PSOut SOut=TFOut::New(FNm);
-    
+
     SOut->PutStrLn("<?xml version='1.0' encoding='UTF-8'?>");
     SOut->PutStrLn("");
     SOut->PutStrLn("<!DOCTYPE rdf:RDF [");
@@ -703,9 +703,9 @@ void TBowDocPart::SaveRdf(const TStr& FNm, const PBowDocBs& BowDocBs) const {
     SOut->PutStrLn("  <owl:versionInfo>\"0.1\"</owl:versionInfo>");
     SOut->PutStrLn("</owl:Ontology>");
     SOut->PutStrLn("");
-    
+
     TIntIntVH DIdClustIdVH; int ClustId = 0;
-    SaveRdfClusts(SOut, BowDocBs, DIdClustIdVH, -1, ClustId);  
+    SaveRdfClusts(SOut, BowDocBs, DIdClustIdVH, -1, ClustId);
 
     TIntV AllDIdV; BowDocBs->GetAllDIdV(AllDIdV);
     TStr BowFNm = TStr::PutFExt(FNm, "_docs.bow");
@@ -728,7 +728,7 @@ void TBowDocPart::SaveRdf(const TStr& FNm, const PBowDocBs& BowDocBs) const {
         SOut->PutStrLn(TStr::Fmt("  <jsikm:locationOfInstance>%s#%d</jsikm:locationOfInstance>", ShortBowFNm.CStr(), DId));
         SOut->PutStrLn("</jsikm:OntoGenClassProperties>");
         SOut->PutStrLn("");
-    }        
+    }
 
     SOut->PutStrLn("</rdf:RDF>");
     SOut->Flush();
@@ -767,10 +767,10 @@ PBowSpV TBowClust::GetConceptSpV(
   } else {
     // prepare data
     int Words=BowDocWgtBs->GetWords();
-    TFltV WordWgtSumV(Words); double WordWgtSum=0;
+    TFltV WordWgtSumV(Words);
     int DIds=DIdV.Len();
     // prepare document weights
-    TIntFltH DocIdToWgtH(DIds); 
+    TIntFltH DocIdToWgtH(DIds);
     for (int DIdN=0; DIdN<DocIdWgtPrV.Len(); DIdN++){
       DocIdToWgtH.AddDat(DocIdWgtPrV[DIdN].Val1, DocIdWgtPrV[DIdN].Val2);
     }
@@ -785,7 +785,7 @@ PBowSpV TBowClust::GetConceptSpV(
       int WIds=SpV->GetWIds();
       for (int WIdN=0; WIdN<WIds; WIdN++){
         int WId; double WordWgt; SpV->GetWIdWgt(WIdN, WId, WordWgt);
-        WordWgtSumV[WId]+=DocWgt.Val*WordWgt; WordWgtSum+=DocWgt.Val*WordWgt;
+        WordWgtSumV[WId]+=DocWgt.Val*WordWgt;
       }
     }
     // extract non-zero word weights

--- a/src/glib/mine/btree.h
+++ b/src/glib/mine/btree.h
@@ -947,11 +947,13 @@ public:
 	}
 
 	void Clr() {
-		int nUsed = 0, nFree = 0;
+		int nFree = 0;
 		for (TNodeId node = 0; node < nodes.Len(); node++) {
 			if (nodes[node].Empty()) { nFree++; continue; }
-			nUsed++; }
-		Assert(nFree == freeNodes.Len());
+		}
+		if (nFree != freeNodes.Len()) {
+			Assert(nFree == freeNodes.Len());
+		}
 		nodes.Clr(); freeNodes.Clr(); }
 
 	// Dummy method for compatibility with TBtreeNodeMemStore_Paranoid.
@@ -1081,12 +1083,12 @@ public:
 	}
 
 	void Clr() {
-		int nUsed = 0, nFree = 0;
+		int nFree = 0;
 		for (TNodeId node = 0; node < nodes.Len(); node++) {
 			if (nodes[node].Empty()) { nFree++; continue; }
 			IAssert(nodes[node]->nodeId == node);
 			IAssert(nodes[node]->checkedOut == 0);
-			nUsed++; }
+		}
 		IAssert(nFree == freeNodes.Len());
 		nodes.Clr(); freeNodes.Clr(); }
 

--- a/src/glib/mine/cfyres.cpp
+++ b/src/glib/mine/cfyres.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -9,8 +9,8 @@
 //////////////////////////////////////////////////////////////////////////
 // Classification Results
 TCfyRes::TCfyRes() {
-    AccMom = TMom::New(); PrecMom = TMom::New(); 
-    RecMom = TMom::New(); F1Mom = TMom::New(); 
+    AccMom = TMom::New(); PrecMom = TMom::New();
+    RecMom = TMom::New(); F1Mom = TMom::New();
     BreakEvenPointMom = TMom::New(); AvgPrecMom = TMom::New();
 	const int Folds = 11; DecPrecMomV.Gen(Folds); DecRecMomV.Gen(Folds);
 	for (int FoldN = 0; FoldN < Folds; FoldN++) {
@@ -31,9 +31,9 @@ TCfyRes::TCfyRes(TCountCfyRes& CfyRes) {
     BreakEvenPointMom->Add(CfyRes.BreakEvenPoint());
     BreakEvenPointMom->Def();
 
-	const int Folds = 11; 
+	const int Folds = 11;
 	DecPrecMomV.Gen(Folds); DecRecMomV.Gen(Folds);
-	TFltV DecPrecV, DecRecV; 
+	TFltV DecPrecV, DecRecV;
 	CfyRes.DecPrecRec(DecPrecV, DecRecV);
 	for (int FoldN = 0; FoldN < Folds; FoldN++) {
 		DecPrecMomV[FoldN] = TMom::New();
@@ -45,14 +45,14 @@ TCfyRes::TCfyRes(TCountCfyRes& CfyRes) {
 	}
 
 	CfyRes.DecRoc(LastRocV);
-}; 
+};
 
 void TCfyRes::Add(TCfyRes& CfyRes) {
     AccMom->Add(CfyRes.Acc()); PrecMom->Add(CfyRes.Prec());
     RecMom->Add(CfyRes.Rec()); F1Mom->Add(CfyRes.F1());
     BreakEvenPointMom->Add(CfyRes.BreakEvenPoint());
     AvgPrecMom->Add(CfyRes.AvgPrec());
-	const int Folds = DecPrecMomV.Len(); 
+	const int Folds = DecPrecMomV.Len();
 	for (int FoldN = 0; FoldN < Folds; FoldN++) {
 		DecPrecMomV[FoldN]->Add(CfyRes.PrecDec(FoldN));
 		DecRecMomV[FoldN]->Add(CfyRes.RecDec(FoldN));
@@ -63,7 +63,7 @@ void TCfyRes::Add(TCfyRes& CfyRes) {
 void TCfyRes::Def() {
     AccMom->Def(); PrecMom->Def(); RecMom->Def();
     F1Mom->Def(); BreakEvenPointMom->Def(); AvgPrecMom->Def();
-	const int Folds = DecPrecMomV.Len(); 
+	const int Folds = DecPrecMomV.Len();
 	for (int FoldN = 0; FoldN < Folds; FoldN++) {
 		DecPrecMomV[FoldN]->Def();
 		DecRecMomV[FoldN]->Def();
@@ -76,7 +76,7 @@ TStr TCfyRes::GetStatStr(const TStr& Desc) {
         100.0*Prec(), 100.0*PrecStDiv(), 100.0*Rec(), 100.0*RecStDiv(), 100.0*F1(), 100.0*F1StDiv());
     StatStr += TStr::Fmt("acc: [%5.2f%%,%5.2f%%] avgprec: [%5.2f%%,%5.2f%%] BEP:[%5.2f%%,%5.2f%%]\n",
         100.0*Acc(), 100.0*AccStDiv(), 100.0*AvgPrec(), 100.0*AvgPrecStDiv(), 100.0*BreakEvenPoint(), 100.0*BreakEvenPointStDiv());
-	//const int Folds = DecPrecMomV.Len(); 
+	//const int Folds = DecPrecMomV.Len();
 	//StatStr += "Prec:";
 	//for (int FoldN = 0; FoldN < Folds; FoldN++) {
 	//	StatStr += (FoldN % 4 == 0) ? "\n" : " ";
@@ -109,9 +109,9 @@ void TCfyRes::PrTabVals(PSOut SOut, const TStr& Nm) {
     SOut->PutFlt(Rec()); SOut->PutCh('\t'); SOut->PutFlt(RecStDiv()); SOut->PutCh('\t');
     SOut->PutFlt(F1()); SOut->PutCh('\t'); SOut->PutFlt(F1StDiv()); SOut->PutCh('\t');
     SOut->PutFlt(Acc()); SOut->PutCh('\t'); SOut->PutFlt(AccStDiv()); SOut->PutCh('\t');
-    SOut->PutFlt(BreakEvenPoint()); SOut->PutCh('\t'); SOut->PutFlt(BreakEvenPointStDiv()); 
+    SOut->PutFlt(BreakEvenPoint()); SOut->PutCh('\t'); SOut->PutFlt(BreakEvenPointStDiv());
     for (int StatN = 0; StatN < GetStats(); StatN++) {
-        SOut->PutCh('\t'); SOut->PutFlt(GetStatWgt(StatN)); }    
+        SOut->PutCh('\t'); SOut->PutFlt(GetStatWgt(StatN)); }
     SOut->PutCh('\n');
 }
 
@@ -119,8 +119,8 @@ void TCfyRes::PrTabVals(PSOut SOut, const TStr& Nm) {
 // Count -- Classification Results
 void TCountCfyRes::GetDec(const TFltV& ValV, TFltV& DecValV) {
 	const int Folds = 10, Vals = ValV.Len(); DecValV.Gen(Folds + 1);
-	for (int Fold = 0; Fold <= Folds; Fold++) { 
-		const int ValN = TInt::GetMn(Vals-1, 
+	for (int Fold = 0; Fold <= Folds; Fold++) {
+		const int ValN = TInt::GetMn(Vals-1,
 			TFlt::Round((double(Fold) / double(Folds)) * double(Vals)));
 		DecValV[Fold] = ValV[ValN];
 	}
@@ -128,8 +128,8 @@ void TCountCfyRes::GetDec(const TFltV& ValV, TFltV& DecValV) {
 
 void TCountCfyRes::GetDec(const TFltPrV& ValV, TFltPrV& DecValV) {
 	const int Folds = 10, Vals = ValV.Len(); DecValV.Gen(Folds + 1);
-	for (int Fold = 0; Fold <= Folds; Fold++) { 
-		const int ValN = TInt::GetMn(Vals-1, 
+	for (int Fold = 0; Fold <= Folds; Fold++) {
+		const int ValN = TInt::GetMn(Vals-1,
 			TFlt::Round((double(Fold) / double(Folds)) * double(Vals)));
 		DecValV[Fold] = ValV[ValN];
 	}
@@ -149,10 +149,10 @@ TCfyRes TCountCfyRes::ToMacroTCfyRes(TVec<TCountCfyRes>& CfyResV) {
 void TCountCfyRes::Add(const double& PredCls, const double& TrueCls) {
 	ResultV.Add(TFltKd(PredCls, TrueCls));
 	ResultVSorted = false;
-	if (TrueCls > 0.0) { 
+	if (TrueCls > 0.0) {
         if (PredCls > 0.0) { TPos++; }
         else { FNeg++; }
-	} else if (TrueCls < 0.0) { 
+	} else if (TrueCls < 0.0) {
         if (PredCls < 0.0) { TNeg++; }
         else { FPos++; }
     } else { Fail; }
@@ -176,8 +176,8 @@ double TCountCfyRes::AvgPrec() {
 double TCountCfyRes::BreakEvenPoint() {
 	PrepareResultV();
     const int Len = ResultV.Len();
-    int TP = 0, FP = 0, TN = FPos + TNeg, FN = TPos + FNeg;
-    double Prec = 1.0, Rec = 0.0, Diff = 1.0, BEP = 0.0; 
+    int TP = 0, FP = 0, FN = TPos + FNeg;
+    double Prec = 1.0, Rec = 0.0, Diff = 1.0, BEP = 0.0;
 
     for (int i = 0; i < Len; i++) {
         if (Diff > TFlt::Abs(Prec - Rec) && Prec != 0.0 && Rec != 0.0) {
@@ -187,9 +187,9 @@ double TCountCfyRes::BreakEvenPoint() {
         if (ResultV[i].Dat > 0.0) {
             FN--; TP++;
         } else {
-            TN--; FP++; 
+            FP++;
         }
-        Prec = (double)TP/(TP+FP); 
+        Prec = (double)TP/(TP+FP);
         Rec = (double)TP/(TP+FN);
     }
 
@@ -199,14 +199,14 @@ double TCountCfyRes::BreakEvenPoint() {
 void TCountCfyRes::PrecRec(TFltV& PrecV, TFltV& RecV) {
 	PrepareResultV();
     const int Len = ResultV.Len();
-    int TP = 0, FP = 0, TN = FPos + TNeg, FN = TPos + FNeg;
-    double Prec = 1.0, Rec = 0.0; 
+    int TP = 0, FP = 0, FN = TPos + FNeg;
+    double Prec = 1.0, Rec = 0.0;
     PrecV.Gen(Len+1, 0); RecV.Gen(Len+1,0);
 
     PrecV.Add(Prec); RecV.Add(Rec);
     for (int i = 0; i < Len; i++) {
         if (ResultV[i].Dat > 0.0) { FN--; TP++; }
-        else { TN--; FP++; }
+        else { FP++; }
         Prec = (double)TP/(TP+FP); Rec = (double)TP/(TP+FN);
         PrecV.Add(Prec); RecV.Add(Rec);
     }
@@ -218,7 +218,7 @@ void TCountCfyRes::DecPrecRec(TFltV& DecPrecV, TFltV& DecRecV) {
 }
 
 void TCountCfyRes::Roc(TFltPrV& RocV) {
-	PrepareResultV(); 
+	PrepareResultV();
     const int Len = ResultV.Len(); RocV.Gen(Len, 0);
     int TP = 0, FP = 0, TN = FPos + TNeg, FN = TPos + FNeg;
     for (int i = 0; i < Len; i++) {

--- a/src/glib/mine/stemming.cpp
+++ b/src/glib/mine/stemming.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -76,9 +76,9 @@ PStemmer TStemmer::ParseJson(const PJsonVal& StemmerVal, const bool& RealWordP) 
 		return TStemmer::New((StemmerType == "porter") ? stmtPorter : stmtNone, RealWordP);
 	} else if (StemmerVal->IsObj()) {
         TStr StemmerType = StemmerVal->GetObjStr("type", "none");
-        const bool RealWordP = StemmerVal->GetObjBool("realWord", RealWordP);
-        return TStemmer::New((StemmerType == "porter") ? stmtPorter : stmtNone, RealWordP);            
-    }    
+        const bool _RealWordP = StemmerVal->GetObjBool("realWord", RealWordP);
+        return TStemmer::New((StemmerType == "porter") ? stmtPorter : stmtNone, _RealWordP);
+    }
     throw TExcept::New("Unknown stemmer definiton " + StemmerVal->SaveStr());
 }
 
@@ -114,9 +114,9 @@ char *TPorterStemmer::StemInPlace(char *pWord){
     char c1 = pEnd[-1], c2 = pEnd[-2], c3 = pEnd[-3]; bool b = false;
     if (c1 == 'D' && c2 == 'E')
     {
-      if (c3 == 'E') 
+      if (c3 == 'E')
         { if (MeasureG0(pStart, pEnd - 3)) pEnd--, len--; } // (m > 0) EED -> EE
-      else if (HasVowels(pStart, pEnd - 2)) 
+      else if (HasVowels(pStart, pEnd - 2))
         pEnd -= 2, len -= 2, b = true; // (*v*) ED -> eps
     }
     else if (c1 == 'G' && c2 == 'N' && c3 == 'I' && HasVowels(pStart, pEnd - 3))
@@ -149,7 +149,7 @@ char *TPorterStemmer::StemInPlace(char *pWord){
   // length has to be at least 5 characters.
   if (len >= 5)
   {
-    char c1 = pEnd[-1], c2 = pEnd[-2], c3 = pEnd[-3]; 
+    char c1 = pEnd[-1], c2 = pEnd[-2], c3 = pEnd[-3];
     if (c1 == 'L' && c2 == 'A' && c3 == 'N' && len >= 8 &&
       pEnd[-4] == 'O' && pEnd[-5] == 'I' && pEnd[-6] == 'T')
     {
@@ -168,9 +168,9 @@ char *TPorterStemmer::StemInPlace(char *pWord){
       MeasureG0(pStart, pEnd - 4)) pEnd--, len--; // (m > 0) IZER -> IZE.
     else if (c1 == 'I' && c2 == 'L')
     {
-      if (c3 == 'B' && MeasureG0(pStart, pEnd - 3)) 
+      if (c3 == 'B' && MeasureG0(pStart, pEnd - 3))
         pEnd[-1] = 'E'; // (m > 0) BLI -> BLE
-      else if (c3 == 'L' && pEnd[-4] == 'A' && MeasureG0(pStart, pEnd - 4)) 
+      else if (c3 == 'L' && pEnd[-4] == 'A' && MeasureG0(pStart, pEnd - 4))
         pEnd -= 2, len -= 2; // (m > 0) ALLI -> AL
       else if (len >= 7 && c3 == 'T' && pEnd[-4] == 'N' && pEnd[-5] == 'E' && MeasureG0(pStart, pEnd - 5))
         pEnd -= 2, len -= 2; // (m > 0) ENTLI -> ENT
@@ -187,7 +187,7 @@ char *TPorterStemmer::StemInPlace(char *pWord){
       else if (c4 == 'V' && c5 == 'I' && MeasureG0(pStart, pEnd - 5))
         pEnd[-3] = 'E', pEnd -= 2, len -= 2; // (m > 0) IVITI -> IVE
       else if (c4 == 'L' && c5 == 'I' && len >= 8 && pEnd[-6] == 'B' &&
-        MeasureG0(pStart, pEnd - 6)) pEnd[-5] = 'L', pEnd[-4] = 'E', 
+        MeasureG0(pStart, pEnd - 6)) pEnd[-5] = 'L', pEnd[-4] = 'E',
         pEnd -= 3, len -= 3; // (m > 0) BILITI -> BLE
     }
     else if (c1 == 'N' && c2 == 'O' && c3 == 'I' && len >= 7 && pEnd[-4] == 'T' &&
@@ -207,7 +207,7 @@ char *TPorterStemmer::StemInPlace(char *pWord){
       if ((c5 == 'E' && c6 == 'V' && c7 == 'I') || // (m > 0) IVENESS -> IVE
         (c5 == 'L' && c6 == 'U' && c7 == 'F') || // (m > 0) FULNESS -> FUL
         (c5 == 'S' && c6 == 'U' && c7 == 'O'))   // (m > 0) OUSNESS -> OUS
-        if (MeasureG0(pStart, pEnd - 7)) pEnd -= 4, len -= 4; 
+        if (MeasureG0(pStart, pEnd - 7)) pEnd -= 4, len -= 4;
     }
     else if (c1 == 'I' && c2 == 'G' && c3 == 'O' && len >= 6 && pEnd[-4] == 'L' &&
       MeasureG0(pStart, pEnd - 4)) pEnd--, len--; // (m > 0) LOGY -> LOG
@@ -218,7 +218,7 @@ char *TPorterStemmer::StemInPlace(char *pWord){
   // Step 3.
   if (len >= 5)
   {
-    char c1 = pEnd[-1], c2 = pEnd[-2], c3 = pEnd[-3]; 
+    char c1 = pEnd[-1], c2 = pEnd[-2], c3 = pEnd[-3];
     if (c1 == 'E' && c2 == 'T' && c3 == 'A' && len >= 7 &&
       pEnd[-4] == 'C' && pEnd[-5] == 'I' && MeasureG0(pStart, pEnd - 5))
       pEnd -= 3, len -= 3; // (m > 0) ICATE -> IC

--- a/src/glib/mine/unicodebow.cpp
+++ b/src/glib/mine/unicodebow.cpp
@@ -1,12 +1,12 @@
 ﻿/**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
 #include "unicodebow.h"
-#include <iostream> 
+#include <iostream>
 
 namespace TUnicodeVSM {
 	int64 loadToCBuffer(FILE** id, char *buffer, int64 dol = 134217728, char newline = '\n'){
@@ -156,12 +156,12 @@ namespace TUnicodeVSM {
 		WordNgrams.Save(SOut);
 		Ngrams.Save(SOut);
 		Matrix.Save(SOut);
-		//Added 
+		//Added
 		InvDoc.Save(SOut);
 		NDocs.Save(SOut);
 		TFidf.Save(SOut);
 	}
-	
+
 	void TGlibUBow::LoadBin(TSIn& SIn){
 		Option.Load(SIn);
 		Lang.Load(SIn);
@@ -201,7 +201,7 @@ namespace TUnicodeVSM {
 			TFidf.Load(SIn);
 		}
 	}
-	
+
 	void TGlibUBow::DelMatrix(){
 		this->Matrix.Clr();
 	}
@@ -259,7 +259,7 @@ namespace TUnicodeVSM {
 		this->BrOnSt = BrOnSt;
 	}
 	//WordNgrams need further testing
-	TVec<TIntKd> TGlibUBow::TextToVec(TUStr& Text){	
+	TVec<TIntKd> TGlibUBow::TextToVec(TUStr& Text){
 		switch (Option) {
 		case tWord:
 			return this->_TokenizeWords(Text);
@@ -281,7 +281,7 @@ namespace TUnicodeVSM {
 	void TGlibUBow::TextToVec(TUStr& Text, TPair<TIntV, TFltV>& SparseVec) {
 		TVec<TIntKd> SpVec = TextToVec(Text);
 		//Convert
-		TIntV IdxV; 
+		TIntV IdxV;
 		TFltV ValV;
 		IdxV.Gen(SpVec.Len());
 		ValV.Gen(SpVec.Len());
@@ -474,7 +474,7 @@ namespace TUnicodeVSM {
 		return TGlibUBow::AddTokenizeSimpleNgrams(Text, true, false, false);
 		//return this->Vector;
 	}
-		
+
 	void TGlibUBow::Tokenize(TUStr& Doc){
 		switch (this->Option.Val){
 		case tWordNgram:
@@ -797,7 +797,6 @@ namespace TUnicodeVSM {
 			TChineseTokenizer::TokenizeClean(Text.GetStr(), Words, Seperators);
 		}
 
-		int i = 0;
 		TLst<TUStr>::PLstNd WordNode = Words.First();
 		TLst<TBool>::PLstNd BoolNode = Seperators.First();
 		while (WordNode){//i < Words.Len()
@@ -844,7 +843,6 @@ namespace TUnicodeVSM {
 			}
 			BoolNode = BoolNode->NextNd;
 			WordNode = WordNode->NextNd;
-			i++;
 		}
 	}
 	void TGlibUBow::CompactVocabulary(TIntV& WordIndex, TInt Shift){

--- a/src/glib/mine/vizmap.cpp
+++ b/src/glib/mine/vizmap.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -16,11 +16,11 @@ int TVizMapLink::GetPointN(const int& PointN) const {
 
 //////////////////////////////////////////////////////////////////////////
 // Visualization-Map-Landscape
-TVizMapLandscape::TVizMapLandscape(const TVizMapLandscapeV& CatLandscapeV, 
-        const PVizMapLandscape& FullLandscape, const TIntH& CatIdH, 
+TVizMapLandscape::TVizMapLandscape(const TVizMapLandscapeV& CatLandscapeV,
+        const PVizMapLandscape& FullLandscape, const TIntH& CatIdH,
         const double& MxCover, const double& MnCover, const int& MnCats) {
 
-    const int Cats = CatLandscapeV.Len(); 
+    const int Cats = CatLandscapeV.Len();
     IAssert(Cats > 0); IAssert(Cats < TInt::Mx);
     const int XDim = CatLandscapeV[0]->GetXDim();
     const int YDim = CatLandscapeV[0]->GetYDim();
@@ -33,7 +33,7 @@ TVizMapLandscape::TVizMapLandscape(const TVizMapLandscapeV& CatLandscapeV,
             HeightMatrixVV(XPos, YPos) = sdouble(FullLandscape->GetHeight(XPos, YPos));
         }
     }
-    // eliminate too or non frequent categories    
+    // eliminate too or non frequent categories
     TIntH CatIdToCountH; TIntH EdgeCatH;
     forever {
         // anything left to remove
@@ -76,7 +76,7 @@ TVizMapLandscape::TVizMapLandscape(const TVizMapLandscapeV& CatLandscapeV,
             EdgeCatH.AddDat(MnCatId);
         } else {
             break; // nothing left to remove or non too frequent anymore
-        } 
+        }
     }
     // prepare a list of remaining categories
     TIntV SelCatIdV;
@@ -135,7 +135,7 @@ int TVizMapLandscape::GetCatFromCoord(const double& X, const double& Y) {
 }
 
 void TVizMapLandscape::CalcStart(const int& XDim, const int& YDim, const double& Sigma) {
-    PKernel Kernel = TRadialKernel::New(1/Sigma); 
+    PKernel Kernel = TRadialKernel::New(1/Sigma);
     CalcMatrixVV.Gen(XDim, YDim);
     CalcMatrixVV.PutAll(0.0);
 
@@ -158,7 +158,7 @@ void TVizMapLandscape::CalcStart(const int& XDim, const int& YDim, const double&
     }
 }
 
-void TVizMapLandscape::CalcPutStamp(const double& PointX, 
+void TVizMapLandscape::CalcPutStamp(const double& PointX,
         const double& PointY, const double& PointWgt) {
 
     const int Width = CalcMatrixVV.GetXDim();
@@ -173,44 +173,44 @@ void TVizMapLandscape::CalcPutStamp(const double& PointX,
     const int LowY = TInt::GetMx(DocY-StampHeight, -1);
     const int HighX = TInt::GetMn(DocX+StampWidth, Width);
     const int HighY = TInt::GetMn(DocY+StampHeight, Height);
-    // lower right part of stamp                     
+    // lower right part of stamp
     for (int x = DocX; x < HighX; x++) {
         for (int y = DocY; y < HighY; y++) {
             EAssertR(0 <= x && x < Width, TInt(x).GetStr());
             EAssertR(0 <= y && y < Height, TInt(y).GetStr());
             EAssertR(0 <= x-DocX && x-DocX < StampWidth, TInt(x).GetStr());
             EAssertR(0 <= y-DocY && y-DocY < StampHeight, TInt(y).GetStr());
-            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(x-DocX,y-DocY); 
+            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(x-DocX,y-DocY);
         }
     }
-    // lower left part of stamp                     
+    // lower left part of stamp
     for (int x = DocX-1; x > LowX; x--) {
         for (int y = DocY; y < HighY; y++) {
             EAssertR(0 <= x && x < Width, TInt(x).GetStr());
             EAssertR(0 <= y && y < Height, TInt(y).GetStr());
             EAssertR(0 <= DocX-x && DocX-x < StampWidth, TInt(x).GetStr());
             EAssertR(0 <= y-DocY && y-DocY < StampHeight, TInt(y).GetStr());
-            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(DocX-x,y-DocY); 
+            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(DocX-x,y-DocY);
         }
     }
-    // upper right part of stamp                     
+    // upper right part of stamp
     for (int x = DocX; x < HighX; x++) {
         for (int y = DocY-1; y > LowY; y--) {
             EAssertR(0 <= x && x < Width, TInt(x).GetStr());
             EAssertR(0 <= y && y < Height, TInt(y).GetStr());
             EAssertR(0 <= x-DocX && x-DocX < StampWidth, TInt(x).GetStr());
             EAssertR(0 <= DocY-y && DocY-y < StampHeight, TInt(y).GetStr());
-            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(x-DocX,DocY-y); 
+            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(x-DocX,DocY-y);
         }
     }
-    // upper left part of stamp                     
+    // upper left part of stamp
     for (int x = DocX-1; x > LowX; x--) {
         for (int y = DocY-1; y > LowY; y--) {
             EAssertR(0 <= x && x < Width, TInt(x).GetStr());
             EAssertR(0 <= y && y < Height, TInt(y).GetStr());
             EAssertR(0 <= DocX-x && DocX-x < StampWidth, TInt(x).GetStr());
             EAssertR(0 <= DocY-y && DocY-y < StampHeight, TInt(y).GetStr());
-            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(DocX-x,DocY-y); 
+            CalcMatrixVV(x,y) += PointWgt * CalcStampVV(DocX-x,DocY-y);
         }
     }
 }
@@ -248,36 +248,36 @@ void TVizMapLandscape::CalcFinish(const double& MxVal, const int& Levels) {
 
 //////////////////////////////////////////////////////////////////////////
 // Visualization-Map-Frame
-TVizMapFrame::TVizMapFrame(): PointV(), LinkV(), FrameSortN(-1) { 
+TVizMapFrame::TVizMapFrame(): PointV(), LinkV(), FrameSortN(-1) {
 }
 
 TVizMapFrame::TVizMapFrame(TSIn& SIn) {
     PointV.Load(SIn); LinkV.Load(SIn);
     FrameNmStr.Load(SIn); FrameSortN.Load(SIn);
-    LandscapeV.Load(SIn); 
+    LandscapeV.Load(SIn);
     QueryLandscape = PVizMapLandscape(SIn);
     PointBowDocBs = PBowDocBs(SIn);
     KeyWdBowDocBs = PBowDocBs(SIn);
     KeyWdSpVV.Load(SIn);
     LinkBowDocBs = PBowDocBs(SIn);
     LinkSpVV.Load(SIn);
-    KeyWdPointV.Load(SIn); KeyWdV.Load(SIn);  
+    KeyWdPointV.Load(SIn); KeyWdV.Load(SIn);
     CatNmH.Load(SIn); DId2PointNMap.Load(SIn);
 }
 
-TVizMapFrame::TVizMapFrame(TSIn& SIn, PBowDocBs _PointBowDocBs, 
+TVizMapFrame::TVizMapFrame(TSIn& SIn, PBowDocBs _PointBowDocBs,
         PBowDocBs _KeyWdBowDocBs, PBowDocBs _LinkBowDocBs) {
 
     PointV.Load(SIn); LinkV.Load(SIn);
     FrameNmStr.Load(SIn); FrameSortN.Load(SIn);
-    LandscapeV.Load(SIn); 
+    LandscapeV.Load(SIn);
     QueryLandscape = PVizMapLandscape(SIn);
     PointBowDocBs = _PointBowDocBs;
     KeyWdBowDocBs = _KeyWdBowDocBs;
     KeyWdSpVV.Load(SIn);
     LinkBowDocBs = _LinkBowDocBs;
     LinkSpVV.Load(SIn);
-    KeyWdPointV.Load(SIn); KeyWdV.Load(SIn);  
+    KeyWdPointV.Load(SIn); KeyWdV.Load(SIn);
     CatNmH.Load(SIn); DId2PointNMap.Load(SIn);
 }
 
@@ -288,7 +288,7 @@ void TVizMapFrame::Save(TSOut& SOut, const bool& SaveBows) const {
     if (SaveBows) { PointBowDocBs.Save(SOut); }
     if (SaveBows) { KeyWdBowDocBs.Save(SOut); } KeyWdSpVV.Save(SOut);
     if (SaveBows) { LinkBowDocBs.Save(SOut); } LinkSpVV.Save(SOut);
-    KeyWdPointV.Save(SOut); KeyWdV.Save(SOut); 
+    KeyWdPointV.Save(SOut); KeyWdV.Save(SOut);
     CatNmH.Save(SOut); DId2PointNMap.Save(SOut);
 }
 
@@ -327,43 +327,43 @@ int TVizMapFrame::AddLink(PVizMapLink VizMapLink) {
     return LinkN;
 }
 
-void TVizMapFrame::AddLandscape(const int& XDim, const int& YDim, 
+void TVizMapFrame::AddLandscape(const int& XDim, const int& YDim,
         const double& Sigma, const bool& PointWgtP) {
 
     PVizMapLandscape NewLandscape = TVizMapLandscape::New();
     NewLandscape->CalcStart(XDim, YDim, Sigma);
-    
+
     const int Points = GetPoints();
     for (int PointN = 0; PointN < Points; PointN++) {
         const PVizMapPoint VizMapPoint = GetPoint(PointN);
         const double PointWgt = PointWgtP ? VizMapPoint->GetWgt() : 1.0;
         NewLandscape->CalcPutStamp(VizMapPoint->GetPointX(),
-            VizMapPoint->GetPointY(), PointWgt); 
+            VizMapPoint->GetPointY(), PointWgt);
     }
 
     NewLandscape->CalcFinish(1.0, 3);
     LandscapeV.Add(NewLandscape);
 }
 
-void TVizMapFrame::AddLandscapeFromLndMrk(const int& XDim, 
-        const int& YDim, const double& Sigma, 
+void TVizMapFrame::AddLandscapeFromLndMrk(const int& XDim,
+        const int& YDim, const double& Sigma,
         const TVec<TFltV>& LndMrkPointV) {
 
     PVizMapLandscape NewLandscape = TVizMapLandscape::New();
     NewLandscape->CalcStart(XDim, YDim, Sigma);
-    
+
     const int LndMrkPoints = LndMrkPointV.Len();
     for (int LndMrkPointN = 0; LndMrkPointN < LndMrkPoints; LndMrkPointN++) {
         const TFltV LndMrkPoint = LndMrkPointV[LndMrkPointN];
         IAssert(LndMrkPoint.Len() == 2);
-        NewLandscape->CalcPutStamp(LndMrkPoint[0], LndMrkPoint[1], 1.0); 
+        NewLandscape->CalcPutStamp(LndMrkPoint[0], LndMrkPoint[1], 1.0);
     }
 
     NewLandscape->CalcFinish(1.0, 3);
-    LandscapeV.Add(NewLandscape);    
+    LandscapeV.Add(NewLandscape);
 }
 
-void TVizMapFrame::AddLandscapeWithCats(const int& XDim, const int& YDim, 
+void TVizMapFrame::AddLandscapeWithCats(const int& XDim, const int& YDim,
         const double& Sigma, const bool& PointWgtP) {
 
     TIntKdV CountCatIdV;
@@ -401,8 +401,8 @@ void TVizMapFrame::AddLandscapeWithCats(const int& XDim, const int& YDim,
             }
         }
         FullLandscape->CalcPutStamp(VizMapPoint->GetPointX(),
-            VizMapPoint->GetPointY(), PointWgt); 
-    } 
+            VizMapPoint->GetPointY(), PointWgt);
+    }
     // finish the category landscapes
     for (int CatIdN = 0; CatIdN < Cats; CatIdN++) {
         const int CatId = BigCatIdH.GetKey(CatIdN);
@@ -410,8 +410,8 @@ void TVizMapFrame::AddLandscapeWithCats(const int& XDim, const int& YDim,
         CatLandscapeV[CatIdN]->CalcFinish(MxVal, 3);
     }
     FullLandscape->CalcFinish(1.0, 3);
-    // and finaly make one overal landscape    
-    LandscapeV.Add(TVizMapLandscape::New(CatLandscapeV, 
+    // and finaly make one overal landscape
+    LandscapeV.Add(TVizMapLandscape::New(CatLandscapeV,
         FullLandscape, BigCatIdH, 0.6, 0.1, 2));
 }
 
@@ -445,15 +445,15 @@ TStr TVizMapFrame::GetDocUrl(const int& PointN) const {
     else { return ""; }
 }
 
-int TVizMapFrame::GenKeyWd(const TFltV& CoordV, const double& Radius, 
-        const int& MxKeyWd, TStrV& KeyWdStrV, const bool& DistWgtP, 
+int TVizMapFrame::GenKeyWd(const TFltV& CoordV, const double& Radius,
+        const int& MxKeyWd, TStrV& KeyWdStrV, const bool& DistWgtP,
         const bool& PointWgtP, const bool& BackKeyWdP) const {
 
     // do we have keyword information?
-    if (KeyWdBowDocBs.Empty() || KeyWdSpVV.Empty()) { 
+    if (KeyWdBowDocBs.Empty() || KeyWdSpVV.Empty()) {
         KeyWdStrV.Clr(); return 0; }
     // average documents inside circle
-    TFltV FullKeyWdStrV(KeyWdBowDocBs->GetWords()); 
+    TFltV FullKeyWdStrV(KeyWdBowDocBs->GetWords());
     FullKeyWdStrV.PutAll(0.0);
     const TVizMapPointV& _PointV = KeyWdPointV.Empty() ? PointV : KeyWdPointV;
     const int Points = _PointV.Len(); int UsedPoints = 0, CenterPoints = 0;
@@ -490,7 +490,7 @@ int TVizMapFrame::GenKeyWd(const TFltV& CoordV, const double& Radius,
     WgtWIdKdV.Sort(false);
     KeyWdStrV.Gen(MxKeyWd, 0); int WIdN = 0;
     while (WIdN < MxKeyWd) {
-        if (WIdN >= WgtWIdKdV.Len()) { return UsedPoints; } 
+        if (WIdN >= WgtWIdKdV.Len()) { return UsedPoints; }
         if (WgtWIdKdV[WIdN].Key.Val < 0.001) { return UsedPoints; }
 
         const int WId = WgtWIdKdV[WIdN].Dat;
@@ -500,10 +500,10 @@ int TVizMapFrame::GenKeyWd(const TFltV& CoordV, const double& Radius,
     return UsedPoints;
 }
 
-void TVizMapFrame::GenKeyWds(const int& KeyWds, const double& Radius, 
+void TVizMapFrame::GenKeyWds(const int& KeyWds, const double& Radius,
         const int& Candidantes, const int& RndSeed, const TFltRect& Rect) {
 
-    KeyWdV.Gen(KeyWds, 0); TRnd Rnd(RndSeed); TStrV KeyWdStrV; 
+    KeyWdV.Gen(KeyWds, 0); TRnd Rnd(RndSeed); TStrV KeyWdStrV;
     const double MnX = Rect.GetMnX(), MnY = Rect.GetMnY();
     const double LenX = Rect.GetXLen(), LenY = Rect.GetYLen();
     for (int KeyWdN = 0; KeyWdN < KeyWds; KeyWdN++) {
@@ -535,19 +535,19 @@ void TVizMapFrame::CalcDId2PointNMap() {
 }
 
 void TVizMapFrame::SaveVrml(const TStr& VrmlFNm, PVizMapLandscape Landscape,
-        const bool& ShowDocNmP, const bool& ShowDocPtP, 
-        const bool& ShowKeyWdP, const double& FontSize, 
-        const TStr& SkyColor, const TStr& TerrainColor, 
+        const bool& ShowDocNmP, const bool& ShowDocPtP,
+        const bool& ShowKeyWdP, const double& FontSize,
+        const TStr& SkyColor, const TStr& TerrainColor,
         const TStr& KeywordColor, const TStr& DocNmColor) {
 
     PSOut SOut = TFOut::New(VrmlFNm);
     TVrml::InsertHeader(SOut, SkyColor);
 
     const TSFltVV& Rlf = Landscape->HeightVV(); TFltVV NewRlf;
-    const double Scale = TVrml::InsertEvelationGrid(SOut, 
+    const double Scale = TVrml::InsertEvelationGrid(SOut,
         Rlf, NewRlf, TerrainColor, 5, 15.0, 0.7);
 
-    TStr DocSize = TStr::Fmt("%.3f %.3f %.3f", 
+    TStr DocSize = TStr::Fmt("%.3f %.3f %.3f",
       FontSize, FontSize, FontSize);
     for (int PointN = 0; PointN < GetPoints(); PointN++) {
         TStr OrgDocNm = TStr::GetFNmStr(GetPoint(PointN)->GetPointNm());
@@ -562,21 +562,21 @@ void TVizMapFrame::SaveVrml(const TStr& VrmlFNm, PVizMapLandscape Landscape,
         //}
         const double PosX = GetPoint(PointN)->GetPointX();
         const double PosY = GetPoint(PointN)->GetPointY();
-        TVrml::InsertBillboard(SOut, NewRlf, OrgDocNm, KeywordColor, 
+        TVrml::InsertBillboard(SOut, NewRlf, OrgDocNm, KeywordColor,
           DocSize, PosX, PosY, 1.1, Scale, ShowDocNmP, ShowDocPtP);
     }
 
     if (ShowKeyWdP) {
-        TStr KeyWdSize = TStr::Fmt("%.3f %.3f %.3f", 
+        TStr KeyWdSize = TStr::Fmt("%.3f %.3f %.3f",
           0.5*FontSize, 0.5*FontSize, 0.5*FontSize);
         TRnd Rnd(0);
         for (int WdC = 0; WdC < 100; WdC++) {
             const double PosX = Rnd.GetUniDev();
             const double PosY = Rnd.GetUniDev();
-            TStrV KeyWdV; GenKeyWd(TFltV::GetV(PosX, PosY), 
+            TStrV KeyWdV; GenKeyWd(TFltV::GetV(PosX, PosY),
                 0.3, 4, KeyWdV, false, false, true);
             if (KeyWdV.Len() > 0) {
-                TVrml::InsertBillboard(SOut, NewRlf, 
+                TVrml::InsertBillboard(SOut, NewRlf,
                   KeyWdV[Rnd.GetUniDevInt(KeyWdV.Len())], DocNmColor,
                   KeyWdSize, PosX, PosY, 2.0, Scale, true, false);
             }
@@ -584,18 +584,18 @@ void TVizMapFrame::SaveVrml(const TStr& VrmlFNm, PVizMapLandscape Landscape,
         for (int WdC = 0; WdC < 50; WdC++) {
             const double PosX = Rnd.GetUniDev();
             const double PosY = Rnd.GetUniDev();
-            TStrV KeyWdV; GenKeyWd(TFltV::GetV(PosX, PosY), 
+            TStrV KeyWdV; GenKeyWd(TFltV::GetV(PosX, PosY),
                 0.2, 4, KeyWdV, false, false, true);
             if (KeyWdV.Len() > 0) {
-                TVrml::InsertBillboard(SOut, NewRlf, 
-                  KeyWdV[Rnd.GetUniDevInt(KeyWdV.Len())], DocNmColor, 
+                TVrml::InsertBillboard(SOut, NewRlf,
+                  KeyWdV[Rnd.GetUniDevInt(KeyWdV.Len())], DocNmColor,
                   KeyWdSize, PosX, PosY, 2.0, Scale, true, false);
             }
         }
     }
 }
 
-void TVizMapFrame::SaveLegend(const TStr& TxtFNm, const int& LegendGridWidth, 
+void TVizMapFrame::SaveLegend(const TStr& TxtFNm, const int& LegendGridWidth,
         const int& LegendGridHeight) {
 
     TFOut FOut(TxtFNm);
@@ -620,29 +620,29 @@ TVizMap::TVizMap(TSIn& SIn) {
         TInt Frames(SIn);
         VizMapFrameV.Gen(Frames, 0);
         for (int FrameN = 0; FrameN < Frames; FrameN++) {
-            PVizMapFrame Frame = TVizMapFrame::Load(SIn, 
+            PVizMapFrame Frame = TVizMapFrame::Load(SIn,
                 PointBowDocBs, KeyWdBowDocBs, LinkBowDocBs);
             VizMapFrameV.Add(Frame);
         }
     } else {
-        VizMapFrameV.Load(SIn); 
+        VizMapFrameV.Load(SIn);
     }
 }
 
-void TVizMap::Save(TSOut& SOut) const { 
+void TVizMap::Save(TSOut& SOut) const {
     // check if all the Bows in the frames are the same
     TBool AllSameP = true;
     for (int FrameN = 1; FrameN < VizMapFrameV.Len(); FrameN++) {
         PVizMapFrame PrevFrame = VizMapFrameV[FrameN - 1];
         PVizMapFrame Frame = VizMapFrameV[FrameN];
         // compare bow signatures between previous and current frame
-        const bool PointBowP = 
+        const bool PointBowP =
             (Frame->GetPointBow().Empty() && PrevFrame->GetPointBow().Empty()) ||
             (Frame->GetPointBow()->GetSig() == PrevFrame->GetPointBow()->GetSig());
-        const bool KeyWdBowP = 
+        const bool KeyWdBowP =
             (Frame->GetKeyWdBow().Empty() && PrevFrame->GetKeyWdBow().Empty()) ||
             (Frame->GetKeyWdBow()->GetSig() == PrevFrame->GetKeyWdBow()->GetSig());
-        const bool LinkBowP = 
+        const bool LinkBowP =
             (Frame->GetLinkBow().Empty() && PrevFrame->GetLinkBow().Empty()) ||
             (Frame->GetLinkBow()->GetSig() == PrevFrame->GetLinkBow()->GetSig());
         AllSameP = PointBowP && KeyWdBowP && LinkBowP;
@@ -652,7 +652,7 @@ void TVizMap::Save(TSOut& SOut) const {
     // remmaber the way we store bows
     AllSameP.Save(SOut);
     // store frames
-    if (AllSameP) { 
+    if (AllSameP) {
         // first save bows
         PVizMapFrame Frame = VizMapFrameV[0];
         Frame->GetPointBow().Save(SOut);
@@ -661,7 +661,7 @@ void TVizMap::Save(TSOut& SOut) const {
         // save frames without bows
         TInt Frames = VizMapFrameV.Len(); Frames.Save(SOut);
         for (int FrameN = 0; FrameN < Frames; FrameN++) {
-            VizMapFrameV[FrameN]->Save(SOut, false); 
+            VizMapFrameV[FrameN]->Save(SOut, false);
         }
     } else {
         // can't do much...
@@ -669,25 +669,25 @@ void TVizMap::Save(TSOut& SOut) const {
     }
 }
 
-void TVizMap::AddVizMapFrame(const PVizMapFrame& VizMapFrame, const bool& SortedP) { 
+void TVizMap::AddVizMapFrame(const PVizMapFrame& VizMapFrame, const bool& SortedP) {
     if (SortedP) { VizMapFrameV.Add(VizMapFrame); }
     else { VizMapFrameV.AddSorted(VizMapFrame); }
 }
 
-void TVizMap::SaveXmlDoc(TSOut& SOut, const TStr& Nm, const TStr& Body, 
-        const TStr& DisplayBody, const TStrV& CatNmV, const TStrV& AuthorV,  
+void TVizMap::SaveXmlDoc(TSOut& SOut, const TStr& Nm, const TStr& Body,
+        const TStr& DisplayBody, const TStrV& CatNmV, const TStrV& AuthorV,
         const TStr& FrameNm, const int& FrameSortN) {
 
     SOut.PutStrLn(" <document>");
     SOut.PutStrLn("  <name>" + TXmlDoc::GetXmlStr(Nm) + "</name>");
     SOut.PutStrLn("  <body>" + TXmlDoc::GetXmlStr(Body) + "</body>");
-    if (!DisplayBody.Empty()) { 
+    if (!DisplayBody.Empty()) {
         SOut.PutStrLn("  <display_body>" + TXmlDoc::GetXmlStr(DisplayBody) + "</display_body>");
     }
     if (!CatNmV.Empty()) {
         SOut.PutStrLn("  <categories>");
         for (int CatNmN = 0; CatNmN < CatNmV.Len(); CatNmN++) {
-            SOut.PutStrLn("   <category>" + 
+            SOut.PutStrLn("   <category>" +
                 TXmlDoc::GetXmlStr(CatNmV[CatNmN]) + "</category>");
         }
         SOut.PutStrLn("  </categories>");
@@ -695,12 +695,12 @@ void TVizMap::SaveXmlDoc(TSOut& SOut, const TStr& Nm, const TStr& Body,
     if (!AuthorV.Empty()) {
         SOut.PutStrLn("  <authors>");
         for (int AuthorN = 0; AuthorN < AuthorV.Len(); AuthorN++) {
-            SOut.PutStrLn("   <author>" + 
+            SOut.PutStrLn("   <author>" +
                 TXmlDoc::GetXmlStr(AuthorV[AuthorN]) + "</author>");
         }
         SOut.PutStrLn("  </authors>");
     }
-    if (!FrameNm.Empty() && (FrameSortN != -1)) { 
+    if (!FrameNm.Empty() && (FrameSortN != -1)) {
         SOut.PutStrLn(TStr::Fmt("  <frame id=\"%d\">%s</frame>",
             FrameSortN, TXmlDoc::GetXmlStr(FrameNm).CStr()));
     }
@@ -754,7 +754,7 @@ void TVizMapLndMrk::SaveXml(const TStr& XmlFNm) {
     Landscape->CalcStart(400, 400, 0.02);
     for (int LndMrkN = 0; LndMrkN < LndMrks; LndMrkN++) {
         const TFltV& PointV = GetLndMrkPointV(LndMrkN);
-        Landscape->CalcPutStamp(PointV[0], PointV[1], 1.0); 
+        Landscape->CalcPutStamp(PointV[0], PointV[1], 1.0);
     }
     Landscape->CalcFinish(1.0, 3);
     // output landscape
@@ -842,14 +842,14 @@ TVizMapXmlDocBs::TVizMapXmlDocBs(const TStr& XmlFNm, const TWPt<TNotify>& Notify
         if (XmlTok->IsTagTok("display_body")) {
             VizMapXmlDoc.DisplayBody = XmlTok->GetTagVal("display_body", false); }
         // read categories
-        TXmlTokV CatTokV; XmlTok->GetTagTokV("categories|category", CatTokV); 
+        TXmlTokV CatTokV; XmlTok->GetTagTokV("categories|category", CatTokV);
         for (int CatTokN = 0; CatTokN < CatTokV.Len(); CatTokN++) {
             TStr CatNm = CatTokV[CatTokN]->GetTokStr(false);
             int CatId = CatNmH.AddKey(CatNm.GetTrunc());
             VizMapXmlDoc.CatIdV.Add(CatId);
         }
         // read authors
-        TXmlTokV AuthorTokV; XmlTok->GetTagTokV("authors|author", AuthorTokV); 
+        TXmlTokV AuthorTokV; XmlTok->GetTagTokV("authors|author", AuthorTokV);
         for (int AuthorTokN = 0; AuthorTokN < AuthorTokV.Len(); AuthorTokN++) {
             TStr AuthorNm = AuthorTokV[AuthorTokN]->GetTokStr(false);
             int AuthorId = AuthorNmH.AddKey(AuthorNm.GetTrunc());
@@ -874,14 +874,14 @@ TVizMapXmlDocBs::TVizMapXmlDocBs(const TStr& XmlFNm, const TWPt<TNotify>& Notify
         if (!FrameNmToSortN.Empty()) {
             FrameSortNToDocId.AddDat(VizMapXmlDoc.FrameSortN).Add(DocId);
         }
-    } 
+    }
     Notify->OnStatus(TStr::Fmt("%d", XmlDocs-1));
 }
 
-PBowDocBs TVizMapXmlDocBs::LoadBowDocBs(const TStr& XmlFNm, PSwSet SwSet, 
+PBowDocBs TVizMapXmlDocBs::LoadBowDocBs(const TStr& XmlFNm, PSwSet SwSet,
         PStemmer Stemmer, const int& MxNGramLen, const int& MnNGramFq) {
 
-    // parse xml    
+    // parse xml
     PVizMapXmlDocBs XmlDocBs = TVizMapXmlDocBs::New(XmlFNm);
     const TVizMapXmlDocV& XmlDocV = XmlDocBs->XmlDocV;
     // load documents to for NGrams
@@ -891,8 +891,8 @@ PBowDocBs TVizMapXmlDocBs::LoadBowDocBs(const TStr& XmlFNm, PSwSet SwSet,
         for (int XmlDocN = 0; XmlDocN < XmlDocV.Len(); XmlDocN++) {
             const TVizMapXmlDoc& XmlDoc = XmlDocV[XmlDocN];
             DocBodyV.Add(XmlDoc.Nm + "\n" + XmlDoc.Body);
-        }    
-        NGramBs = TNGramBs::GetNGramBsFromHtmlStrV(DocBodyV, 
+        }
+        NGramBs = TNGramBs::GetNGramBsFromHtmlStrV(DocBodyV,
             MxNGramLen, MnNGramFq, SwSet, Stemmer);
     }
     // load documents to Bow
@@ -912,8 +912,9 @@ PBowDocBs TVizMapXmlDocBs::LoadBowDocBs(const TStr& XmlFNm, PSwSet SwSet,
             if (AuthorIdN > 0) { AuthorStr + ", "; }
             AuthorStr += XmlDocBs->AuthorNmH.GetKey(AuthorId);
         }
-        if (AuthorStr.Empty()) { DocBody = DocBody; }
-        else { DocBody = AuthorStr + "\r\n" + DocBody;}
+        if (!AuthorStr.Empty()) {
+            DocBody = AuthorStr + "\r\n" + DocBody;
+        }
         // add it to bow
         const int DId = BowDocBs->AddHtmlDoc(DocNm, CatNmV, DocBody, true);
         // check if we have a more user friendly version of the document
@@ -922,13 +923,13 @@ PBowDocBs TVizMapXmlDocBs::LoadBowDocBs(const TStr& XmlFNm, PSwSet SwSet,
                 AuthorStr + "\r\n" + XmlDoc.DisplayBody;
             BowDocBs->PutDocStr(DId, DisplayBody);
         }
-    }        
+    }
     return BowDocBs;
 }
 
 //////////////////////////////////////////////////////////////////////////
 // Visualization-Map Factory
-void TVizMapFactory::CG(const TMatrix& Matrix, const TFltV& b, 
+void TVizMapFactory::CG(const TMatrix& Matrix, const TFltV& b,
         TFltV& x, const TWPt<TNotify>& Notify, const int& MaxStep, const double& EpsTer) {
     int M = x.Len(), R = b.Len(), i;
     TFltV r(M), p(M), q(M), tmp(R);
@@ -969,9 +970,9 @@ void TVizMapFactory::CG(const TMatrix& Matrix, const TFltV& b,
     }
 }
 
-void TVizMapFactory::MakeFlat(const PSVMTrainSet& Set, 
-        const TVizDistType& DistType, TVec<TFltV>& DocPointV, 
-        const int& MxStep, const int& MxSecs, const double& MnDiff, 
+void TVizMapFactory::MakeFlat(const PSVMTrainSet& Set,
+        const TVizDistType& DistType, TVec<TFltV>& DocPointV,
+        const int& MxStep, const int& MxSecs, const double& MnDiff,
         const bool& RndStartPos, const TWPt<TNotify>& Notify) {
 
 
@@ -985,7 +986,7 @@ void TVizMapFactory::MakeFlat(const PSVMTrainSet& Set,
         TRnd Rnd1(1), Rnd2(2);
         TLinAlgTransform::FillRnd(x, Rnd1); TLinAlgTransform::FillRnd(y, Rnd2);
     } else {
-        EAssertR(DocPointV.Len() == Len, TStr::Fmt("%d == %d", DocPointV.Len(), Len));        
+        EAssertR(DocPointV.Len() == Len, TStr::Fmt("%d == %d", DocPointV.Len(), Len));
         for (int PntN = 0; PntN < Len; PntN++) {
             x[PntN] = DocPointV[PntN][0];
             y[PntN] = DocPointV[PntN][1];
@@ -1037,7 +1038,7 @@ void TVizMapFactory::MakeFlat(const PSVMTrainSet& Set,
             Diff = TMath::Mx(Diff, TFlt::Abs(dxdy[i]), TFlt::Abs(dxdy[Len+i]));
         }
         Step = Step + 1;
-        const int RunTimeSec = 
+        const int RunTimeSec =
           int(TTm::GetDiffMSecs(StartTm, TTm::GetCurUniTm()) / 1000);
 
         // check conditions
@@ -1072,17 +1073,17 @@ void TVizMapFactory::NormalizePoints(TVec<TFltV>& PointV) {
         for (int i = 0; i < PointV.Len(); i++) {
             const double OldVal = PointV[i][d];
             const double NewVal = 0.96*(OldVal - Min)/Diff + 0.02;
-            EAssertR(0.0 <= NewVal && NewVal <= 1.0, 
-              TStr::Fmt("%d:%d %g %g %g %g %g", i, 
+            EAssertR(0.0 <= NewVal && NewVal <= 1.0,
+              TStr::Fmt("%d:%d %g %g %g %g %g", i,
               PointV.Len(), Min, Max, Diff, OldVal, NewVal));
             PointV[i][d] = NewVal;
         }
     }
 }
 
-void TVizMapFactory::LsiMds(TVec<PBowSpV> DocSpV, PSemSpace SemSpace, 
-        TVec<TFltV>& DocPointV, const double& SemSpaceThresh, 
-        const int& MxStep, const int& MxSecs, const double& MnDiff, 
+void TVizMapFactory::LsiMds(TVec<PBowSpV> DocSpV, PSemSpace SemSpace,
+        TVec<TFltV>& DocPointV, const double& SemSpaceThresh,
+        const int& MxStep, const int& MxSecs, const double& MnDiff,
         const TWPt<TNotify>& Notify) {
 
     double ApproxVal;
@@ -1091,23 +1092,23 @@ void TVizMapFactory::LsiMds(TVec<PBowSpV> DocSpV, PSemSpace SemSpace,
         DocSpV, SemSpaceThresh, ApproxVal, 3);
     EAssert((SemSpcDim == -1) || (SemSpcDim > 0));
     if (SemSpcDim == -1) { SemSpcDim = SemSpace->GetVecs(); }
-    Notify->OnStatus(TStr::Fmt("Norm(dim:%d) = [avg: %.3f, mn:%.3f]", 
+    Notify->OnStatus(TStr::Fmt("Norm(dim:%d) = [avg: %.3f, mn:%.3f]",
         SemSpcDim, ApproxVal, SemSpaceThresh));
 
     Notify->OnStatus("Multidimensional Scaling:");
     const int Docs = DocSpV.Len();
     TVec<PBowSpV> ProjDocSpV(Docs, 0);
     for (int DocN = 0; DocN < Docs; DocN++) {
-        ProjDocSpV.Add(SemSpace->ProjectSpV(DocSpV[DocN], SemSpcDim, false)); }    
+        ProjDocSpV.Add(SemSpace->ProjectSpV(DocSpV[DocN], SemSpcDim, false)); }
     PSVMTrainSet DocSet = TBowDocBs2TrainSet::NewBowNoCat(ProjDocSpV);
-    MakeFlat(DocSet, vdtEucl, DocPointV, MxStep, 
+    MakeFlat(DocSet, vdtEucl, DocPointV, MxStep,
         MxSecs, MnDiff, DocPointV.Empty(), Notify);
     NormalizePoints(DocPointV);
 }
 
 PVizMapFrame TVizMapFactory::DocLsiMds(PBowDocWgtBs BowDocWgtBs,
-        PSemSpace SemSpace, const TVec<TFltV>& _DocPointV, 
-        const double& SemSpaceThresh, const int& MxStep, 
+        PSemSpace SemSpace, const TVec<TFltV>& _DocPointV,
+        const double& SemSpaceThresh, const int& MxStep,
         const int& MxSecs, const double& MnDiff, const TWPt<TNotify>& Notify) {
 
     // calculate positions for documents
@@ -1115,11 +1116,11 @@ PVizMapFrame TVizMapFactory::DocLsiMds(PBowDocWgtBs BowDocWgtBs,
     TVec<PBowSpV> DocSpV(Docs, 0);
     for (int DIdN = 0; DIdN < Docs; DIdN++) {
         const int DId = BowDocWgtBs->GetDId(DIdN);
-        DocSpV.Add(BowDocWgtBs->GetSpV(DId)); 
+        DocSpV.Add(BowDocWgtBs->GetSpV(DId));
     }
     TVec<TFltV> DocPointV = _DocPointV;
-    LsiMds(DocSpV, SemSpace, DocPointV, SemSpaceThresh, MxStep, MxSecs, MnDiff, Notify);    
-    
+    LsiMds(DocSpV, SemSpace, DocPointV, SemSpaceThresh, MxStep, MxSecs, MnDiff, Notify);
+
     // generate a VizMapFrame from positions
     PVizMapFrame VizMapFrame = TVizMapFrame::New();
     // add document points
@@ -1133,8 +1134,8 @@ PVizMapFrame TVizMapFactory::DocLsiMds(PBowDocWgtBs BowDocWgtBs,
     return VizMapFrame;
 }
 
-void TVizMapFactory::AddDocMetadata(PVizMapFrame VizMapFrame, 
-        PBowDocBs PointBowDocBs, PBowDocBs KeyWdBowDocBs, 
+void TVizMapFactory::AddDocMetadata(PVizMapFrame VizMapFrame,
+        PBowDocBs PointBowDocBs, PBowDocBs KeyWdBowDocBs,
         PBowDocWgtBs KeyWdBowDocWgtBs, PVizMapLndMrk VizMapLndMrk) {
 
     // categories
@@ -1171,7 +1172,7 @@ void TVizMapFactory::AddDocMetadata(PVizMapFrame VizMapFrame,
         TBowSpVV KeyWdSpVV;
         const int LndMrks = VizMapLndMrk->GetLndMrks();
         for (int LndMrkN = 0; LndMrkN < LndMrks; LndMrkN++) {
-            PVizMapPoint KeyWdPoint = 
+            PVizMapPoint KeyWdPoint =
                 TVizMapPoint::New(VizMapLndMrk->GetLndMrkPointV(LndMrkN));
             VizMapFrame->AddKeyWdPoint(KeyWdPoint);
             PBowSpV KeyWdSpV = VizMapLndMrk->GetLndMrkSpV(LndMrkN);
@@ -1182,15 +1183,15 @@ void TVizMapFactory::AddDocMetadata(PVizMapFrame VizMapFrame,
 }
 
 void TVizMapFactory::LndMrk(PBowDocWgtBs BowDocWgtBs, PBowSim BowSim,
-        const TVec<PBowSpV>& ClustSpV, const TVec<TFltV>& ClustPointV, 
+        const TVec<PBowSpV>& ClustSpV, const TVec<TFltV>& ClustPointV,
         TVec<TFltV>& DocPointV, const int& LinCombNum, const TWPt<TNotify>& Notify) {
-    
+
     const int Clusts = ClustSpV.Len();
     const int TopClustN = TInt::GetMn(LinCombNum, Clusts);
     const int Docs = BowDocWgtBs->GetDocs();
     Notify->OnStatus(TStr::Fmt("Positioning %d documents using %d landmarks:", Docs, Clusts));
-    
-    DocPointV.Gen(Docs, 0); 
+
+    DocPointV.Gen(Docs, 0);
     for (int DocN = 0; DocN < Docs; DocN++) {
         Notify->OnStatus(TStr::Fmt("%d\r", DocN));
         const int DId = BowDocWgtBs->GetDId(DocN);
@@ -1209,22 +1210,22 @@ void TVizMapFactory::LndMrk(PBowDocWgtBs BowDocWgtBs, PBowSim BowSim,
         // calculate document position based on top TopClustN clusters
         DocPointV.Add(TFltV::GetV(0.0, 0.0));
         for (int ClustN = 0; ClustN < TopClustN; ClustN++) {
-            const double SumWgt = (SimSum > 1e-7) ? 
+            const double SumWgt = (SimSum > 1e-7) ?
                 SimClustV[ClustN].Key / SimSum : 0.0;
             const int ClustId = SimClustV[ClustN].Dat;
-            TLinAlg::AddVec(SumWgt, ClustPointV[ClustId], 
+            TLinAlg::AddVec(SumWgt, ClustPointV[ClustId],
                 DocPointV.Last(), DocPointV.Last());
         }
     }
     Notify->OnStatus("");
 }
 
-PVizMapFrame TVizMapFactory::DocLndMrk(PBowDocWgtBs BowDocWgtBs, 
-        const TVec<PBowSpV>& ClustSpV, const TVec<TFltV>& ClustPointV, 
+PVizMapFrame TVizMapFactory::DocLndMrk(PBowDocWgtBs BowDocWgtBs,
+        const TVec<PBowSpV>& ClustSpV, const TVec<TFltV>& ClustPointV,
         const int& LinCombNum, const TWPt<TNotify>& Notify) {
 
-    // calculate positons for 
-    TVec<TFltV> DocPointV; 
+    // calculate positons for
+    TVec<TFltV> DocPointV;
     PBowSim BowSim = TBowSim::New(bstCos);
     LndMrk(BowDocWgtBs, BowSim, ClustSpV, ClustPointV, DocPointV, LinCombNum, Notify);
 
@@ -1244,8 +1245,8 @@ PVizMapFrame TVizMapFactory::DocLndMrk(PBowDocWgtBs BowDocWgtBs,
 
 
 PVizMapFrame TVizMapFactory::ClustLsiMdsDocLndMrk(PBowDocWgtBs BowDocWgtBs,
-        PBowDocPart BowDocPart, PSemSpace SemSpace, const int& LinCombNum, 
-        const double& SemSpaceThresh, const int& MxStep, const int& MxSecs, 
+        PBowDocPart BowDocPart, PSemSpace SemSpace, const int& LinCombNum,
+        const double& SemSpaceThresh, const int& MxStep, const int& MxSecs,
         const double& MnDiff, const TWPt<TNotify>& Notify) {
 
     // calculate positions for clusters' centroids
@@ -1254,7 +1255,7 @@ PVizMapFrame TVizMapFactory::ClustLsiMdsDocLndMrk(PBowDocWgtBs BowDocWgtBs,
     for (int ClustN = 0; ClustN < Clusts; ClustN++) {
         ClustSpV.Add(BowDocPart->GetClust(ClustN)->GetConceptSpV()); }
     TVec<TFltV> ClustPointV; EAssert(ClustPointV.Empty());
-    LsiMds(ClustSpV, SemSpace, ClustPointV, 
+    LsiMds(ClustSpV, SemSpace, ClustPointV,
         SemSpaceThresh, MxStep, MxSecs, MnDiff, Notify);
 
     // finish...
@@ -1276,8 +1277,8 @@ PVizMapFrame TVizMapFactory::NewVizMapFrame(PBowDocBs BowDocBs, PBowDocWgtBs Bow
         VizMapFrame = TVizMapFactory::DocLsiMds(BowDocWgtBs, SemSpace,
             TVec<TFltV>(), 0.93 * SvdThreshold, 5000, 500, 0.0001, Notify);
         Notify->OnStatus("Adding metadata ... ");
-        TVizMapFactory::AddDocMetadata(VizMapFrame, 
-            KeyWdBowDocBs, KeyWdBowDocBs, KeyWdBowDocWgtBs);    
+        TVizMapFactory::AddDocMetadata(VizMapFrame,
+            KeyWdBowDocBs, KeyWdBowDocBs, KeyWdBowDocWgtBs);
         Notify->OnStatus("Calculating background landscapes ... ");
         if (CalcLandscapeP && KeyWdBowDocBs->IsCats()) {
             VizMapFrame->AddLandscape(400, 400, 0.02, LndPointWgt);
@@ -1299,8 +1300,8 @@ PVizMapFrame TVizMapFactory::NewVizMapFrame(PBowDocBs BowDocBs, PBowDocWgtBs Bow
         VizMapFrame = TVizMapFactory::ClustLsiMdsDocLndMrk(BowDocWgtBs, BowDocPart,
             SemSpace, 3, SvdThreshold, 5000, 500, 0.0001, Notify);
         Notify->OnStatus("Adding metadata ... ");
-        TVizMapFactory::AddDocMetadata(VizMapFrame, 
-            KeyWdBowDocBs, KeyWdBowDocBs, KeyWdBowDocWgtBs);    
+        TVizMapFactory::AddDocMetadata(VizMapFrame,
+            KeyWdBowDocBs, KeyWdBowDocBs, KeyWdBowDocWgtBs);
         Notify->OnStatus("Calculating background landscapes ... ");
         double BellSize = 0.02;
         if (BowDocBs->GetDocs() > 1500) BellSize *= 0.7;
@@ -1327,8 +1328,8 @@ PVizMapFrame TVizMapFactory::NewVizMapFrame(PBowDocBs BowDocBs, const int& ThDoc
         ThDocs, Clusts, SvdThreshold, Notify, LndPointWgt, CalcLandscapeP);
 }
 
-PVizMapFrame TVizMapFactory::NewVizMapFrameFromLndMrk(PBowDocBs BowDocBs, 
-        PBowDocWgtBs BowDocWgtBs, PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP, 
+PVizMapFrame TVizMapFactory::NewVizMapFrameFromLndMrk(PBowDocBs BowDocBs,
+        PBowDocWgtBs BowDocWgtBs, PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP,
         const bool& LndMrkKeyWdP, const TWPt<TNotify>& Notify) { // TODO use LndMrkKeyWdP
 
     // position documents using landmarks from the LndMrk
@@ -1336,12 +1337,12 @@ PVizMapFrame TVizMapFactory::NewVizMapFrameFromLndMrk(PBowDocBs BowDocBs,
     Notify->OnStatus("Calculating visualization map ... ");
     const TBowSpVV& LndMrkSpVV = VizMapLndMrk->GetLndMrkSpVV();
     const TVec<TFltV>& LndMrkPointVV = VizMapLndMrk->GetLndMrkPointVV();
-    PVizMapFrame VizMapFrame = DocLndMrk(BowDocWgtBs, 
+    PVizMapFrame VizMapFrame = DocLndMrk(BowDocWgtBs,
         LndMrkSpVV, LndMrkPointVV, 20, Notify);
     // add metadata to the points
     Notify->OnStatus("Adding metadata ... ");
     if (LndMrkKeyWdP) {
-        AddDocMetadata(VizMapFrame, BowDocBs, VizMapLndMrk->GetBowDocBs(), 
+        AddDocMetadata(VizMapFrame, BowDocBs, VizMapLndMrk->GetBowDocBs(),
             VizMapLndMrk->GetBowDocWgtBs(), VizMapLndMrk);
     } else {
         AddDocMetadata(VizMapFrame, BowDocBs, BowDocBs, BowDocWgtBs);
@@ -1353,11 +1354,11 @@ PVizMapFrame TVizMapFactory::NewVizMapFrameFromLndMrk(PBowDocBs BowDocBs,
     if (BowDocBs->GetDocs() > 2000) BellSize *= 0.7;
     if (BowDocBs->GetDocs() > 3000) BellSize *= 0.5;
     if (BowDocBs->GetDocs() > 4000) BellSize *= 0.5;
-    if (!LndMrkLndP && BowDocBs->IsCats()) { 
+    if (!LndMrkLndP && BowDocBs->IsCats()) {
         VizMapFrame->AddLandscape(400, 400, BellSize, false);
     } else if (!LndMrkLndP) {
-        VizMapFrame->AddLandscape(400, 400, BellSize, false); 
-    } else { 
+        VizMapFrame->AddLandscape(400, 400, BellSize, false);
+    } else {
         VizMapFrame->AddLandscapeFromLndMrk(400, 400, BellSize, LndMrkPointVV);
     }
     Notify->OnStatus("Done ... ");
@@ -1372,7 +1373,7 @@ PVizMap TVizMapFactory::NewVizMap(PBowDocBs BowDocBs, PBowDocWgtBs BowDocWgtBs,
         const bool& LndPointWgtP, const bool& CalcLandscapeP) {
 
     return TVizMap::New(NewVizMapFrame(BowDocBs, BowDocWgtBs, KeyWdBowDocBs,
-        KeyWdBowDocWgtBs, ThDocs, Clusts, SvdThreshold, Notify, LndPointWgtP, 
+        KeyWdBowDocWgtBs, ThDocs, Clusts, SvdThreshold, Notify, LndPointWgtP,
         CalcLandscapeP));
 }
 
@@ -1380,14 +1381,14 @@ PVizMap TVizMapFactory::NewVizMap(PBowDocBs BowDocBs, const int& ThDocs,
         const int& Clusts, const double& SvdThreshold, const TWPt<TNotify>& Notify,
         const bool& LndPointWgtP, const bool& CalcLandscapeP) {
 
-    return TVizMap::New(NewVizMapFrame(BowDocBs, ThDocs, Clusts, 
+    return TVizMap::New(NewVizMapFrame(BowDocBs, ThDocs, Clusts,
         SvdThreshold, Notify, LndPointWgtP, CalcLandscapeP));
 }
 
 //////////////////////////////////////////////////////////////////////////
 // Visualization-of-DAX-strucutres (Document-Atlas-Xml format)
-PVizMap TVizMapFactory::NewVizMapStaticDoc(const PVizMapXmlDocBs& XmlDocBs, 
-        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts, 
+PVizMap TVizMapFactory::NewVizMapStaticDoc(const PVizMapXmlDocBs& XmlDocBs,
+        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts,
         const double& SvdThreshold, const TWPt<TNotify>& Notify, const bool& LndPointWgt,
         const bool& CalcLandscapeP) {
 
@@ -1400,14 +1401,14 @@ PVizMap TVizMapFactory::NewVizMapStaticDoc(const PVizMapXmlDocBs& XmlDocBs,
         // add it to the bow
         const int DId = XmlDoc.AddToBowDocBs(XmlDocBs, BowDocBs);
         IAssertR(DId == XmlDocN, TStr::Fmt("%d-%d", DId, XmlDocN));
-    }        
+    }
     // finish ...
-    return NewVizMap(BowDocBs, ThDocs, Clusts, SvdThreshold, 
+    return NewVizMap(BowDocBs, ThDocs, Clusts, SvdThreshold,
         Notify, LndPointWgt, CalcLandscapeP);
 }
 
-PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs, 
-        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts, 
+PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs,
+        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts,
         const double& SvdThreshold, const TWPt<TNotify>& Notify, const bool& LndPointWgt,
         const bool& CalcLandscapeP) {
 
@@ -1422,7 +1423,7 @@ PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs,
         const int FrameSortN = XmlDoc.FrameSortN;
         const TStr& FrameNm = XmlDoc.FrameNm;
         if (FrameSortNToNmH.IsKey(FrameSortN)) {
-            IAssertR(FrameSortNToNmH.GetDat(FrameSortN) == FrameNm, 
+            IAssertR(FrameSortNToNmH.GetDat(FrameSortN) == FrameNm,
                 FrameSortNToNmH.GetDat(FrameSortN) + " != " + FrameNm);
         } else {
             FrameSortNToNmH.AddDat(FrameSortN, FrameNm);
@@ -1431,7 +1432,7 @@ PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs,
         const int DId = XmlDoc.AddToBowDocBs(XmlDocBs, BowDocBs);
         IAssertR(DId == XmlDocN, TStr::Fmt("%d-%d", DId, XmlDocN));
         FrameSortNToDIdVH.AddDat(FrameSortN).Add(DId);
-    }        
+    }
     // sort frames by sort number
     FrameSortNToNmH.SortByKey();
     // prepare map with landmarks
@@ -1445,11 +1446,11 @@ PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs,
         const int FrameSortN = FrameSortNToNmH.GetKey(FrameKeyId);
         // place authors on the map
         const TIntV& FrameDIdV = FrameSortNToDIdVH.GetDat(FrameSortN);
-        Notify->OnStatus(TStr::Fmt("Frame %d/%d (%d)... ", 
+        Notify->OnStatus(TStr::Fmt("Frame %d/%d (%d)... ",
             FrameKeyId+1, FrameSortNToNmH.Len(), FrameDIdV.Len()));
         PBowDocWgtBs BowDocWgtBs = TBowDocWgtBs::New(
             BowDocBs, bwwtLogDFNrmTFIDF, 0, 0, FrameDIdV);
-        PVizMapFrame VizMapFrame = NewVizMapFrameFromLndMrk(BowDocBs, 
+        PVizMapFrame VizMapFrame = NewVizMapFrameFromLndMrk(BowDocBs,
             BowDocWgtBs, VizMapLndMrk, false, false, Notify);
         // add metadata to the frame
         Notify->OnStatus("Adding metadata ... ");
@@ -1461,8 +1462,8 @@ PVizMap TVizMapFactory::NewVizMapDynamicDoc(const PVizMapXmlDocBs& XmlDocBs,
     return VizMap;
 }
 
-PVizMap TVizMapFactory::NewVizMapStaticAuthor(const PVizMapXmlDocBs& XmlDocBs, 
-        PSwSet SwSet, PStemmer Stemmer, const int& MxAuthors, const int& ThDocs, 
+PVizMap TVizMapFactory::NewVizMapStaticAuthor(const PVizMapXmlDocBs& XmlDocBs,
+        PSwSet SwSet, PStemmer Stemmer, const int& MxAuthors, const int& ThDocs,
         const int& Clusts, const double& SvdThreshold, const TWPt<TNotify>& Notify,
         const bool& LndPointWgt, const bool& CalcLandscapeP) {
 
@@ -1521,7 +1522,7 @@ PVizMap TVizMapFactory::NewVizMapStaticAuthor(const PVizMapXmlDocBs& XmlDocBs,
         BowDocBs->PutDocStr(DId, AuthorIdToDisplayBodyH.GetDat(AuthorId));
         // remember map from author to it's document
         AuthorIdToDIdH.AddDat(AuthorId, DId);
-    } 
+    }
     // make viz map frame
     PVizMapFrame VizMapFrame = NewVizMapFrame(BowDocBs, 300, 200, 0.8, Notify, false, true);
     // add weights
@@ -1539,9 +1540,9 @@ PVizMap TVizMapFactory::NewVizMapStaticAuthor(const PVizMapXmlDocBs& XmlDocBs,
     return TVizMap::New(VizMapFrame);
 }
 
-PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs, 
+PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
         PSwSet SwSet, PStemmer Stemmer, const int& MxFrames,
-        const int& MxAuthors, const int& ThDocs, 
+        const int& MxAuthors, const int& ThDocs,
         const int& Clusts, const double& SvdThreshold, const TWPt<TNotify>& Notify,
         const bool& LndPointWgt, const bool& CalcLandscapeP) {
 
@@ -1577,7 +1578,7 @@ PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
         const int FrameSortN = XmlDoc.FrameSortN;
         const TStr& FrameNm = XmlDoc.FrameNm;
         if (FrameSortNToNmH.IsKey(FrameSortN)) {
-            IAssertR(FrameSortNToNmH.GetDat(FrameSortN) == FrameNm, 
+            IAssertR(FrameSortNToNmH.GetDat(FrameSortN) == FrameNm,
                 FrameSortNToNmH.GetDat(FrameSortN) + " != " + FrameNm);
         } else {
             FrameSortNToNmH.AddDat(FrameSortN, FrameNm);
@@ -1591,11 +1592,11 @@ PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
             TIntPr FrameAuthorId(FrameSortN, AuthorId);
             FrameSortNToAuthorIdHH.AddDat(FrameSortN).AddDat(AuthorId)++;
             // add content
-            FrameAuthorIdToBodyH.AddDat(FrameAuthorId) += 
+            FrameAuthorIdToBodyH.AddDat(FrameAuthorId) +=
                 XmlDoc.Nm + " -- " + XmlDoc.Body + "\r\n";
-            TStr DisplayBody = XmlDoc.DisplayBody.Empty() ? 
+            TStr DisplayBody = XmlDoc.DisplayBody.Empty() ?
                 XmlDoc.Body : XmlDoc.DisplayBody;
-            FrameAuthorIdToDisplayBodyH.AddDat(FrameAuthorId) += 
+            FrameAuthorIdToDisplayBodyH.AddDat(FrameAuthorId) +=
                 XmlDoc.Nm + " -- " + DisplayBody + "\r\n";
             // add categories
             for (int CatIdN = 0; CatIdN < XmlDoc.CatIdV.Len(); CatIdN++) {
@@ -1613,15 +1614,15 @@ PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
     // load documents to bow
     TIntPrIntH FrameAuthorIdToDIdH; TIntIntVH FrameToDIdVH;
     int FrameAuthorKeyId = FrameAuthorIdToBodyH.FFirstKeyId();
-    while (FrameAuthorIdToBodyH.FNextKeyId(FrameAuthorKeyId)) {            
+    while (FrameAuthorIdToBodyH.FNextKeyId(FrameAuthorKeyId)) {
         const TIntPr& FrameAuthorId = FrameAuthorIdToBodyH.GetKey(FrameAuthorKeyId);
         const int FrameSortN = FrameAuthorId.Val1;
         const int AuthorId = FrameAuthorId.Val2;
         // read document and add it to bow
-        TStr DocNm = TStr::Fmt("%s [[%d]]", 
+        TStr DocNm = TStr::Fmt("%s [[%d]]",
             XmlDocBs->AuthorNmH.GetKey(AuthorId).CStr(), FrameSortN);
         TStr DocBody = FrameAuthorIdToBodyH.GetDat(FrameAuthorId);
-        const TStrV& CatNmV = FrameAuthorIdToCatNmVH.GetDat(FrameAuthorId);           
+        const TStrV& CatNmV = FrameAuthorIdToCatNmVH.GetDat(FrameAuthorId);
         const int DId = BowDocBs->AddHtmlDoc(DocNm, CatNmV, DocBody, false);
         BowDocBs->PutDocStr(DId, FrameAuthorIdToDisplayBodyH.GetDat(FrameAuthorId));
         // remamber frame autor id to document id map
@@ -1638,12 +1639,12 @@ PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
     while (FrameSortNToNmH.FNextKeyId(FrameKeyId)) {
         const int FrameSortN = FrameSortNToNmH.GetKey(FrameKeyId);
         // place authors on the map
-        Notify->OnStatus(TStr::Fmt("Frame %d/%d... ", 
+        Notify->OnStatus(TStr::Fmt("Frame %d/%d... ",
             FrameKeyId+1, FrameSortNToNmH.Len()));
         const TIntV& FrameDIdV = FrameToDIdVH.GetDat(FrameSortN);
         PBowDocWgtBs BowDocWgtBs = TBowDocWgtBs::New(
             BowDocBs, bwwtLogDFNrmTFIDF, 0, 0, FrameDIdV);
-        PVizMapFrame VizMapFrame = NewVizMapFrameFromLndMrk(BowDocBs, 
+        PVizMapFrame VizMapFrame = NewVizMapFrameFromLndMrk(BowDocBs,
             BowDocWgtBs, VizMapLndMrk, false, false, Notify);
         // add metadata to the frame
         Notify->OnStatus("Adding metadata ... ");
@@ -1669,11 +1670,11 @@ PVizMap TVizMapFactory::NewVizMapDynamicAuthor(const PVizMapXmlDocBs& XmlDocBs,
     return VizMap;
 }
 
-PVizMap TVizMapFactory::NewVizMap(const PVizMapXmlDocBs& XmlDocBs, 
-        const TVizXmlMapType& VizXmlMapType, PSwSet SwSet, PStemmer Stemmer, 
-        const int& ThDocs, const int& Clusts, const double& SvdThreshold, 
+PVizMap TVizMapFactory::NewVizMap(const PVizMapXmlDocBs& XmlDocBs,
+        const TVizXmlMapType& VizXmlMapType, PSwSet SwSet, PStemmer Stemmer,
+        const int& ThDocs, const int& Clusts, const double& SvdThreshold,
         const TWPt<TNotify>& Notify, const bool& LndPointWgt, const bool& CalcLandscapeP) {
-            
+
     // act according to MapType
     if (VizXmlMapType == vxmtStaticDoc) {
         // map with static documents
@@ -1687,7 +1688,7 @@ PVizMap TVizMapFactory::NewVizMap(const PVizMapXmlDocBs& XmlDocBs,
         // map with static authors
         return NewVizMapStaticAuthor(XmlDocBs, SwSet, Stemmer, -1, ThDocs,
             Clusts, SvdThreshold, Notify, LndPointWgt, CalcLandscapeP);
-    } else if (VizXmlMapType == vxmtDynamicAuthor) { 
+    } else if (VizXmlMapType == vxmtDynamicAuthor) {
         // map with dynamic authors
         return NewVizMapDynamicAuthor(XmlDocBs, SwSet, Stemmer, -1, -1, ThDocs,
             Clusts, SvdThreshold, Notify, LndPointWgt, CalcLandscapeP);
@@ -1696,23 +1697,23 @@ PVizMap TVizMapFactory::NewVizMap(const PVizMapXmlDocBs& XmlDocBs,
 }
 
 PVizMap TVizMapFactory::NewVizMap(const TStr& XmlFNm, const TVizXmlMapType& VizXmlMapType,
-        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts, 
+        PSwSet SwSet, PStemmer Stemmer, const int& ThDocs, const int& Clusts,
         const double& SvdThreshold, const TWPt<TNotify>& Notify, const bool& LndPointWgt,
         const bool& CalcLandscapeP) {
 
-    // parse xml    
+    // parse xml
     PVizMapXmlDocBs XmlDocBs = TVizMapXmlDocBs::New(XmlFNm, Notify);
     // make and return
-    return NewVizMap(XmlDocBs, VizXmlMapType, SwSet, Stemmer, 
+    return NewVizMap(XmlDocBs, VizXmlMapType, SwSet, Stemmer,
         ThDocs, Clusts, SvdThreshold, Notify, LndPointWgt, CalcLandscapeP);
 }
 
 //////////////////////////////////////////////////////////////////////////
 // Generation of LandMark-Maps
-PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs, 
-        PBowDocWgtBs BowDocWgtBs, const int& ThDocs, const int& Clusts, 
+PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs,
+        PBowDocWgtBs BowDocWgtBs, const int& ThDocs, const int& Clusts,
         const double& SvdThreshold, const TWPt<TNotify>& Notify) {
-    
+
     Notify->OnStatus(TStr::Fmt("Size of dataset: %d docs", BowDocWgtBs->GetDocs()));
     // load landmarks
     TVec<PBowSpV> LndMrkSpV;
@@ -1735,7 +1736,7 @@ PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs,
         //PBowDocPart BowDocPart = TBowClust::GetKMeansPartForDocWgtBs(
         //    Notify, BowDocWgtBs, BowDocBs, BowSim, Rnd, Clusts, 1, 10, 1);
         // load landmarks
-        const int Clusts = BowDocPart->GetClusts(); 
+        const int Clusts = BowDocPart->GetClusts();
         LndMrkSpV.Gen(Clusts, 0);
         for (int ClustN = 0; ClustN < Clusts; ClustN++) {
             LndMrkSpV.Add(BowDocPart->GetClust(ClustN)->GetConceptSpV()); }
@@ -1752,11 +1753,11 @@ PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs,
     return TVizMapLndMrk::New(BowDocBs, BowDocWgtBs, LndMrkSpV, LndMrkPointV);
 }
 
-PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs, 
-        const TIntV& DIdV, const int& ThDocs, const int& Clusts, 
+PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs,
+        const TIntV& DIdV, const int& ThDocs, const int& Clusts,
         const double& SvdThreshold, const TWPt<TNotify>& Notify) {
 
-    TIntV NewDIdV; 
+    TIntV NewDIdV;
     if (DIdV.Empty()) { BowDocBs->GetAllDIdV(NewDIdV); } else { NewDIdV = DIdV; }
     PBowDocWgtBs BowDocWgtBs = TBowDocWgtBs::New(BowDocBs, bwwtLogDFNrmTFIDF, 0, 0, NewDIdV);
     return NewVizMapLndMrk(BowDocBs, BowDocWgtBs, ThDocs, Clusts, SvdThreshold, Notify);
@@ -1764,20 +1765,20 @@ PVizMapLndMrk TVizMapFactory::NewVizMapLndMrk(PBowDocBs BowDocBs,
 
 //////////////////////////////////////////////////////////////////////////
 // Visualization using Landmark-Maps
-PVizMap TVizMapFactory::NewVizMapFromLndMrk(PBowDocBs BowDocBs, PBowDocWgtBs BowDocWgtBs, 
-        PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP, const bool& LndMrkKeyWdP, 
+PVizMap TVizMapFactory::NewVizMapFromLndMrk(PBowDocBs BowDocBs, PBowDocWgtBs BowDocWgtBs,
+        PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP, const bool& LndMrkKeyWdP,
         const TWPt<TNotify>& Notify) {
 
-    return TVizMap::New(NewVizMapFrameFromLndMrk(BowDocBs, BowDocWgtBs, 
+    return TVizMap::New(NewVizMapFrameFromLndMrk(BowDocBs, BowDocWgtBs,
         VizMapLndMrk, LndMrkLndP, LndMrkKeyWdP, Notify));
 }
 
-PVizMap TVizMapFactory::NewVizMapFromLndMrk(PBowDocBs BowDocBs, const TIntV& DIdV, 
-        PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP, const bool& LndMrkKeyWdP, 
+PVizMap TVizMapFactory::NewVizMapFromLndMrk(PBowDocBs BowDocBs, const TIntV& DIdV,
+        PVizMapLndMrk VizMapLndMrk, const bool& LndMrkLndP, const bool& LndMrkKeyWdP,
         const TBowWordWgtType& WgtType, const TWPt<TNotify>& Notify) {
 
     PBowDocWgtBs BowDocWgtBs = TBowDocWgtBs::New(BowDocBs, WgtType, 0, 0, DIdV);
-    return TVizMap::New(NewVizMapFrameFromLndMrk(BowDocBs, BowDocWgtBs, 
+    return TVizMap::New(NewVizMapFrameFromLndMrk(BowDocBs, BowDocWgtBs,
         VizMapLndMrk, LndMrkLndP, LndMrkKeyWdP, Notify));
 }
 
@@ -1798,11 +1799,11 @@ void TVrml::InsertHeader(PSOut SOut, const TStr& SkyColor) {
     SOut->PutStrLn("}");
 }
 
-double TVrml::InsertEvelationGrid(PSOut SOut, const TSFltVV& Rlf, 
-        TFltVV& NewRlf, const TStr& TerrainColor, const int& N, 
+double TVrml::InsertEvelationGrid(PSOut SOut, const TSFltVV& Rlf,
+        TFltVV& NewRlf, const TStr& TerrainColor, const int& N,
         const double& Height, const double& Spacing) {
 
-    // transform grid of TSFlt to grid of TFlt of hight 
+    // transform grid of TSFlt to grid of TFlt of hight
     // Height and N times less points than in Rlf
     //InfoNotify(TStr::Fmt("%d : %d", Rlf.GetXDim(), Rlf.GetYDim()));
     NewRlf.Gen(Rlf.GetXDim()/N, Rlf.GetYDim()/N);
@@ -1849,9 +1850,9 @@ double TVrml::InsertEvelationGrid(PSOut SOut, const TSFltVV& Rlf,
     return NewRlf.GetXDim() * Spacing;
 }
 
-void TVrml::InsertBillboard(PSOut SOut, const TFltVV& Rlf, 
+void TVrml::InsertBillboard(PSOut SOut, const TFltVV& Rlf,
         const TStr& Text, const TStr& Color, const TStr& Size,
-        const double& x, const double& y, const double& Height, 
+        const double& x, const double& y, const double& Height,
         const double& Scale, bool DoText, bool DoPoint) {
 
     const double Spacing = Scale / Rlf.GetXDim();
@@ -1882,7 +1883,7 @@ void TVrml::InsertBillboard(PSOut SOut, const TFltVV& Rlf,
     if (DoPoint) {
         SOut->PutStrLn("Anchor {");
         SOut->PutStrLn("  children [");
-        SOut->PutStrLn("    Transform {");                                                 
+        SOut->PutStrLn("    Transform {");
         SOut->PutStrLn(TStr::Fmt("      translation %.3f %.3f %.3f", Scale*y, z - 0.95*Height, Scale*x));
         SOut->PutStrLn("      rotation 0 0 1 0");
         SOut->PutStrLn("      children Shape {");

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -611,7 +611,7 @@ TIntV TStore::GetFieldIdV(const TFieldType& Type) {
 }
 
 void TStore::AddTrigger(const PStoreTrigger& Trigger) {
-    TEnv::Logger->OnStatusFmt("Adding trigger to store %s", GetStoreNm().CStr());
+    if (TEnv::Verbosity >= 1) { TEnv::Logger->OnStatusFmt("Adding trigger to store %s", GetStoreNm().CStr()); }
     Trigger->Init(this);
     TriggerV.Add(Trigger);
 }
@@ -5148,7 +5148,7 @@ TQueryItem::TQueryItem(const TWPt<TBase>& Base, const TStr& StoreNm, const TStr&
     QmAssertR(Base->GetIndexVoc()->IsKeyNm(StoreId, KeyNm), "Unknown Key Name: " + KeyNm);
     KeyId = Base->GetIndexVoc()->GetKeyId(StoreId, KeyNm);
     // make sure all the specified word ids are valid
-    for (const uint64& WordId : WordIdV) {
+    for (const uint64 WordId : WordIdV) {
         QmAssertR(Base->GetIndexVoc()->IsWordId(KeyId, WordId), "Unknown word id");
     }
     WordIdV = _WordIdV;
@@ -5596,7 +5596,7 @@ bool TIndex::TQmGixItemPos::Add(const int& Pos) {
 }
 
 // compute the intersection of the current item (this) and Item, where the maximum allowed difference in
-// positions is MaxDiff. If MaxDiff value is negative we have a match if Item pos is on the left or right of 
+// positions is MaxDiff. If MaxDiff value is negative we have a match if Item pos is on the left or right of
 // a position in this
 TIndex::TQmGixItemPos TIndex::TQmGixItemPos::Intersect(const TQmGixItemPos& Item, const int& MaxDiff, int& TotalMatchingDiff) const {
     // first remember the length of boths items

--- a/src/qminer/qminer_storage.h
+++ b/src/qminer/qminer_storage.h
@@ -530,6 +530,9 @@ public:
     void SerializeUpdateInPlace(const PJsonVal& RecVal,
         TThinMIn MIn, const TWPt<TStore>& Store, TIntSet& ChangedFieldIdSet);
 
+    /// Delete TOAST-ed values
+    void DeleteToast(const TMemBase& RecMem);
+
     /// Check if field inside this serializator
     bool IsFieldId(const int& FieldId) const { return FieldIdToSerialDescIdH.IsKey(FieldId); }
     /// Check if field is in fixed part

--- a/test/cpp/files/store1.def
+++ b/test/cpp/files/store1.def
@@ -1,0 +1,46 @@
+[
+	{
+		"name" : "Article",
+		"fields" : [
+			{ "name" : "URI", "type" : "string", "primary" : true },
+			{ "name" : "Url", "type" : "string", "store" : "cache" },
+			{ "name" : "Title", "type" : "string", "store" : "cache" },
+			{ "name" : "Body", "type" : "string", "store" : "cache" }
+		],
+		"joins" : [ ],
+		"keys" : [
+			{ "field" : "Title", "type" : "text_position" },
+			{ "field" : "Body", "type" : "text_position" }
+		],
+		"options": {
+			"type": "paged"
+		}
+	},
+	{
+		"name" : "ArticleMany",
+		"fields" : [
+			{ "name" : "URI", "type" : "string", "primary" : true },
+			{ "name" : "Url", "type" : "string", "store" : "cache" },
+			{ "name" : "Title", "type" : "string", "store" : "cache" },
+			{ "name" : "Body01", "type" : "string", "store" : "cache" },
+			{ "name" : "Body02", "type" : "string", "store" : "cache" },
+			{ "name" : "Body03", "type" : "string", "store" : "cache" },
+			{ "name" : "Body04", "type" : "string", "store" : "cache" },
+			{ "name" : "Body05", "type" : "string", "store" : "cache" },
+			{ "name" : "Body06", "type" : "string", "store" : "cache" },
+			{ "name" : "Body07", "type" : "string", "store" : "cache" },
+			{ "name" : "Body08", "type" : "string", "store" : "cache" },
+			{ "name" : "Body09", "type" : "string", "store" : "cache" },
+			{ "name" : "Body10", "type" : "string", "store" : "cache" }
+		],
+		"joins" : [ ],
+		"keys" : [
+			{ "field" : "Title", "type" : "text_position" },
+			{ "field" : "Body01", "type" : "text_position" }
+		],
+		"options": {
+			"type": "paged"
+		}
+	}
+
+]

--- a/test/cpp/test_blobbs.cpp
+++ b/test/cpp/test_blobbs.cpp
@@ -1,0 +1,65 @@
+#include <base.h>
+
+#include "microtest.h"
+
+TEST(TBlobBs1) {
+    return;
+
+    PBlobBs BlobBs = TGBlobBs::New("./test/cpp/data/test_blobbs.dat", faCreate);
+
+    TMOut MOut; MOut.PutStr("Hello World!");
+    TBlobPt BlobPt = BlobBs->PutBlob(MOut.GetSIn());
+
+    TMOut MOut2; MOut2.PutStr("In the tranquil town of Willowbrook, nestled between emerald hills and a gently meandering river, lived a community bound by friendship and tradition. The townspeople, known for their artisanship and devotion to nature, had crafted a life that thrived on simplicity and harmony. Every morning, the faint melodies of birds would greet the dawn, filling the hearts of the residents with a sense of contentment and connection to the world around them. The local bakery, with its heavenly aroma of freshly baked bread, became a symbol of warmth and unity, a place where neighbors would gather to exchange stories and smiles. In Willowbrook, the essence of life was woven into the very fabric of daily existence, creating an atmosphere of peace and joy that lingered long after the sun had set.");
+    int ReleasedSize = 0;
+    TBlobPt BlobPt2 = BlobBs->PutBlob(BlobPt, MOut2.GetSIn(), ReleasedSize);
+
+    TMOut MOut3; MOut3.PutStr("!dlorW olleH");
+    TBlobPt BlobPt3 = BlobBs->PutBlob(MOut3.GetSIn());
+
+    ASSERT_EQ(BlobPt.GetAddr(), BlobPt3.GetAddr());
+    ASSERT_EQ(ReleasedSize, 16);
+}
+
+TEST(TBlobBs2) {
+    return;
+
+    TBlobPt BlobPt, BlobPt2, BlobPt3;
+    {
+        PBlobBs BlobBs = TGBlobBs::New("./test/cpp/data/test_blobbs.dat", faCreate);
+        TMOut MOut; MOut.PutStr("Hello World!");
+        BlobPt = BlobBs->PutBlob(MOut.GetSIn());
+    }
+
+    {
+        PBlobBs BlobBs = TGBlobBs::New("./test/cpp/data/test_blobbs.dat", faUpdate);
+        TMOut MOut2; MOut2.PutStr("In the tranquil town of Willowbrook, nestled between emerald hills and a gently meandering river, lived a community bound by friendship and tradition. The townspeople, known for their artisanship and devotion to nature, had crafted a life that thrived on simplicity and harmony. Every morning, the faint melodies of birds would greet the dawn, filling the hearts of the residents with a sense of contentment and connection to the world around them. The local bakery, with its heavenly aroma of freshly baked bread, became a symbol of warmth and unity, a place where neighbors would gather to exchange stories and smiles. In Willowbrook, the essence of life was woven into the very fabric of daily existence, creating an atmosphere of peace and joy that lingered long after the sun had set.");
+        int ReleasedSize = 0;
+        BlobPt2 = BlobBs->PutBlob(BlobPt, MOut2.GetSIn(), ReleasedSize);
+        TMOut MOut3; MOut3.PutStr("!dlorW olleH");
+        BlobPt3 = BlobBs->PutBlob(MOut3.GetSIn());
+
+        ASSERT_EQ(ReleasedSize, 16);
+    }
+
+    ASSERT_EQ(BlobPt.GetAddr(), BlobPt3.GetAddr());
+}
+
+TEST(TBlobBs3) {
+    return;
+
+    PBlobBs BlobBs = TMBlobBs::New("./test/cpp/data/test_blobbs.dat", faCreate);
+
+    TMOut MOut; MOut.PutStr("Hello World!");
+    TBlobPt BlobPt = BlobBs->PutBlob(MOut.GetSIn());
+
+    TMOut MOut2; MOut2.PutStr("In the tranquil town of Willowbrook, nestled between emerald hills and a gently meandering river, lived a community bound by friendship and tradition. The townspeople, known for their artisanship and devotion to nature, had crafted a life that thrived on simplicity and harmony. Every morning, the faint melodies of birds would greet the dawn, filling the hearts of the residents with a sense of contentment and connection to the world around them. The local bakery, with its heavenly aroma of freshly baked bread, became a symbol of warmth and unity, a place where neighbors would gather to exchange stories and smiles. In Willowbrook, the essence of life was woven into the very fabric of daily existence, creating an atmosphere of peace and joy that lingered long after the sun had set.");
+    int ReleasedSize = 0;
+    TBlobPt BlobPt2 = BlobBs->PutBlob(BlobPt, MOut2.GetSIn(), ReleasedSize);
+
+    TMOut MOut3; MOut3.PutStr("!dlorW olleH");
+    TBlobPt BlobPt3 = BlobBs->PutBlob(MOut3.GetSIn());
+
+    ASSERT_EQ(BlobPt.GetAddr(), BlobPt3.GetAddr());
+    ASSERT_EQ(ReleasedSize, 16);
+}

--- a/test/cpp/test_pgblob.cpp
+++ b/test/cpp/test_pgblob.cpp
@@ -1,0 +1,95 @@
+#include <base.h>
+
+#include "microtest.h"
+
+TEST(TPgBlob1) {
+    return;
+
+    PPgBlob Blob = TPgBlob::Create("./test/cpp/data/test_pgblob");
+
+    TStr Str1 = "1234567890";
+    TStr Str2 = "ABCDEFGHIJ";
+    const int Recs = 10;
+
+    TChA ChA1;
+    while (ChA1.Len() < 10000) { ChA1 += Str1; }
+    TChA ChA2;
+    while (ChA2.Len() < 10000) { ChA2 += Str2; }
+
+    TVec<TPgBlobPt> PtV;
+    for (int i = 0; i < Recs; i++) {
+        TMOut MOut; TStr::Fmt("%s_%02d", ChA1.CStr(), i).Save(MOut);
+        PtV.Add(Blob->Put(MOut.GetBfAddr(), MOut.Len()));
+        printf("%d Pt: f%d:p%d:i%d\n", i, PtV[i].GetFIx(), PtV[i].GetPg(), PtV[i].GetIIx());
+    }
+    printf("----------------\n");
+
+    for (int i = 0; i < Recs/2; i++) {
+        Blob->Del(PtV[i]);
+    }
+    printf("----------------\n");
+
+    for (int i = 0; i < Recs; i++) {
+        TMOut MOut; TStr::Fmt("%s_%02d", ChA2.CStr(), i).Save(MOut);
+        const TPgBlobPt Pt = Blob->Put(MOut.GetBfAddr(), MOut.Len());
+        printf("%d Pt: f%d:p%d:i%d\n", i, Pt.GetFIx(), Pt.GetPg(), Pt.GetIIx());
+    }
+}
+
+TEST(TPgBlob2) {
+    return;
+
+    PPgBlob Blob = TPgBlob::Create("./test/cpp/data/test_pgblob", TInt::Mega);
+
+    const int Iters = 50;
+    const int Recs = 100000;
+    const int PagesPerFile = 2000000000 / 8192;
+
+    printf("Iters: %d, Recs: %d, PagesPerFile: %d\n", Iters, Recs, PagesPerFile);
+
+    TStr Str = "1234567890";
+
+    THash<TPgBlobPt, TInt> PtSizeH;
+    for (int IterN = 0; IterN < Iters; IterN++) {
+        uint64 StartTm = TTm::GetCurUniMSecs();
+        // insert records
+        for (int i = 0; i < Recs; i++) {
+            const int RecSize = TInt::Rnd.GetUniDevInt(10, 6000);
+            TChA ChA; while (ChA.Len() < RecSize) { ChA += Str; }
+            TMOut MOut; ChA.Save(MOut);
+
+            const TPgBlobPt Pt = Blob->Put(MOut.GetBfAddr(), MOut.Len());
+            PtSizeH.AddDat(Pt, MOut.Len());
+        }
+        const uint64 InsertTm = TTm::GetCurUniMSecs() - StartTm;
+
+        // find max file and page number
+        TIntPr MxPg(-1, -1);
+        int PtKeyId = PtSizeH.FFirstKeyId();
+        while (PtSizeH.FNextKeyId(PtKeyId)) {
+            const TPgBlobPt Pt = PtSizeH.GetKey(PtKeyId);
+            TIntPr PgVal = { Pt.GetFIx(), Pt.GetPg() };
+            if (MxPg < PgVal) { MxPg = PgVal; }
+        }
+
+        // delete half of the records per iteration
+        TVec<TPgBlobPt> PtV; PtSizeH.GetKeyV(PtV);
+        PtV.Shuffle(TInt::Rnd); PtV.Trunc(Recs / 2);
+        StartTm = TTm::GetCurUniMSecs();
+        for (const auto& Pt : PtV) {
+            Blob->Del(Pt);
+            PtSizeH.DelKey(Pt);
+        }
+        const uint64 DeleteTm = TTm::GetCurUniMSecs() - StartTm;
+
+        double StoredSize = 0;
+        PtKeyId = PtSizeH.FFirstKeyId();
+        while (PtSizeH.FNextKeyId(PtKeyId)) {
+            StoredSize += PtSizeH[PtKeyId];
+        }
+
+        const double Ratio = StoredSize / (MxPg.Val1 * PagesPerFile + MxPg.Val2);
+        printf("Iter: %d, PtSet.Len(): %d, MxPg: %d:%d, Ratio: %.2f, InsertTm: %d, DeleteTm: %d\n",
+            IterN, PtSizeH.Len(), MxPg.Val1.Val, MxPg.Val2.Val, Ratio, int(InsertTm), int(DeleteTm));
+    }
+}

--- a/test/cpp/test_storage.cpp
+++ b/test/cpp/test_storage.cpp
@@ -1,0 +1,193 @@
+#include <qminer.h>
+#include <qminer_storage.h>
+
+#include "microtest.h"
+
+using namespace TQm;
+using namespace TQm::TStorage;
+
+const uint64 StoreCacheSize = 100 * TInt::Mega;
+const uint64 IndexCacheSize = 100 * TInt::Mega;
+
+PJsonVal MakeArticleSmall(const int& Id) {
+    PJsonVal ArticleVal = TJsonVal::NewObj();
+    ArticleVal->AddToObj("URI", TStr::Fmt("URI_%d", Id));
+    ArticleVal->AddToObj("Url", "The Url");
+    ArticleVal->AddToObj("Title", "The Title");
+    ArticleVal->AddToObj("Body", "The Body");
+    return ArticleVal;
+}
+
+TStr MakeStr(const int& Len) {
+    TStr Str = "1234567890";
+    TChA ChA; while (ChA.Len() < Len) { ChA += Str; }
+    return ChA;
+}
+
+PJsonVal MakeArticleBig(const int& Id, const int& FieldLen) {
+    const TStr FieldStr = MakeStr(FieldLen);
+    PJsonVal ArticleVal = TJsonVal::NewObj();
+    ArticleVal->AddToObj("URI", TStr::Fmt("URI_%d", Id));
+    ArticleVal->AddToObj("Url", FieldStr);
+    ArticleVal->AddToObj("Title", FieldStr);
+    ArticleVal->AddToObj("Body", FieldStr);
+    return ArticleVal;
+}
+
+PJsonVal MakeArticleBigMany(const int& Id, const int& FieldLen) {
+    const TStr FieldStr = MakeStr(FieldLen);
+    PJsonVal ArticleVal = TJsonVal::NewObj();
+    ArticleVal->AddToObj("URI", TStr::Fmt("URI_%d", Id));
+    ArticleVal->AddToObj("Url", FieldStr);
+    ArticleVal->AddToObj("Title", FieldStr);
+    ArticleVal->AddToObj("Body01", FieldStr);
+    ArticleVal->AddToObj("Body02", FieldStr);
+    ArticleVal->AddToObj("Body03", FieldStr);
+    ArticleVal->AddToObj("Body04", FieldStr);
+    ArticleVal->AddToObj("Body05", FieldStr);
+    ArticleVal->AddToObj("Body06", FieldStr);
+    ArticleVal->AddToObj("Body07", FieldStr);
+    ArticleVal->AddToObj("Body08", FieldStr);
+    ArticleVal->AddToObj("Body09", FieldStr);
+    ArticleVal->AddToObj("Body10", FieldStr);
+    return ArticleVal;
+}
+
+double FileSize() {
+    return TFile::GetSize("./test/cpp/data/ArticlePgBlob.bin000") * 1.0;
+}
+
+TEST(TInit) {
+    TUnicodeDef::Load("./src/glib/bin/UnicodeDef.Bin");
+    TQm::TEnv::Init();
+	TQm::TEnv::InitLogger(0, "std", true);
+}
+
+TEST(TStore1) {
+    return;
+
+    TStr StoreJsonFNm = "./test/cpp/files/store1.def";
+    PJsonVal StoreDefVal = TJsonVal::GetValFromStr(TStr::LoadTxt(StoreJsonFNm));
+
+    int ArticleId = 0;
+    uint64 Records = 0;
+    const int ArticleFieldLen = 1000;
+    const int Recs = 100000;
+    const double PercDelete = 0.5;
+    const double PercAdd = 1.0;
+    const int Iters = 100;
+
+    try {
+        PBase Base = NewBase("./test/cpp/data/", StoreDefVal, IndexCacheSize,
+            StoreCacheSize, true, TStrUInt64H(), TStrUInt64H(), false, 128, true);
+        PStore ArticleStore = Base->GetStoreByStoreNm("Article");
+
+        for (int i = 0; i < Recs; i++) {
+            ArticleStore->AddRec(MakeArticleBig(ArticleId++, ArticleFieldLen));
+        }
+        printf("Added %d records\n", Recs);
+
+        Records = ArticleStore->GetRecs();
+        SaveBase(Base);
+    } catch (PExcept Except) {
+        printf("Exception: %s\n", Except->GetMsgStr().CStr());
+    }
+
+    const double RecSize = FileSize() / Records;
+    printf("File size: %.0fMB    %.0f / article\n", FileSize() / (1024.0*1024.0), FileSize() / Records);
+
+    for (int IterN = 0; IterN < Iters; IterN++) {
+        printf("Iter: %d\n", IterN);
+
+        try {
+            PBase Base = LoadBase("./test/cpp/data/", faUpdate, IndexCacheSize,
+                StoreCacheSize, TStrUInt64H(), TStrUInt64H(), false, 128);
+            PStore ArticleStore = Base->GetStoreByStoreNm("Article");
+
+            PRecSet DeleteSet = ArticleStore->GetRndRecs((int)(PercDelete * Recs));
+            TUInt64V DelRecIdV; DeleteSet->GetRecIdV(DelRecIdV);
+            ArticleStore->DeleteRecs(DelRecIdV);
+
+            Records = ArticleStore->GetRecs();
+            SaveBase(Base);
+        } catch (PExcept Except) {
+            printf("Exception: %s\n", Except->GetMsgStr().CStr());
+        }
+
+        printf("File size: %.0fMB  ...  %.1fx\n", FileSize() / (1024.0*1024.0), (FileSize() / Records) / RecSize);
+
+        try {
+            PBase Base = LoadBase("./test/cpp/data/", faUpdate, IndexCacheSize,
+                StoreCacheSize, TStrUInt64H(), TStrUInt64H(), false, 128);
+            PStore ArticleStore = Base->GetStoreByStoreNm("Article");
+
+            for (int i = 0; i < (int)(PercAdd * Recs); i++) {
+                ArticleStore->AddRec(MakeArticleBig(ArticleId++, ArticleFieldLen));
+            }
+
+            Records = ArticleStore->GetRecs();
+            SaveBase(Base);
+        } catch (PExcept Except) {
+            printf("Exception: %s\n", Except->GetMsgStr().CStr());
+        }
+
+        printf("File size: %.0fMB  ...  %.1fx\n", FileSize() / (1024.0*1024.0), (FileSize() / Records) / RecSize);
+    }
+}
+
+
+TEST(TStore2) {
+    return;
+
+    TStr StoreJsonFNm = "./test/cpp/files/store1.def";
+    PJsonVal StoreDefVal = TJsonVal::GetValFromStr(TStr::LoadTxt(StoreJsonFNm));
+
+    try {
+        PBase Base = NewBase("./test/cpp/data/", StoreDefVal, IndexCacheSize,
+            StoreCacheSize, true, TStrUInt64H(), TStrUInt64H(), false, 128, true);
+        PStore ArticleStore = Base->GetStoreByStoreNm("Article");
+
+        ArticleStore->AddRec(MakeArticleBig(123, 10000));
+
+        printf("Records: %d\n", (int)ArticleStore->GetRecs());
+
+        SaveBase(Base);
+    } catch (PExcept Except) {
+        printf("Exception: %s\n", Except->GetMsgStr().CStr());
+    }
+
+    try {
+        PBase Base = LoadBase("./test/cpp/data/", faUpdate, IndexCacheSize,
+            StoreCacheSize, TStrUInt64H(), TStrUInt64H(), false, 128);
+        PStore ArticleStore = Base->GetStoreByStoreNm("Article");
+
+        TUInt64V DelRecIdV; ArticleStore->GetAllRecs()->GetRecIdV(DelRecIdV);
+        ArticleStore->DeleteRecs(DelRecIdV);
+        printf("Records: %d\n", (int)ArticleStore->GetRecs());
+
+        SaveBase(Base);
+    } catch (PExcept Except) {
+        printf("Exception: %s\n", Except->GetMsgStr().CStr());
+    }
+}
+
+TEST(TStore3) {
+    return;
+
+    TStr StoreJsonFNm = "./test/cpp/files/store1.def";
+    PJsonVal StoreDefVal = TJsonVal::GetValFromStr(TStr::LoadTxt(StoreJsonFNm));
+
+    try {
+        PBase Base = NewBase("./test/cpp/data/", StoreDefVal, IndexCacheSize,
+            StoreCacheSize, true, TStrUInt64H(), TStrUInt64H(), false, 128, true);
+        PStore ArticleStore = Base->GetStoreByStoreNm("ArticleMany");
+
+        ArticleStore->AddRec(MakeArticleBigMany(123, 500));
+
+        printf("Records: %d\n", (int)ArticleStore->GetRecs());
+
+        SaveBase(Base);
+    } catch (PExcept Except) {
+        printf("Exception: %s\n", Except->GetMsgStr().CStr());
+    }
+}


### PR DESCRIPTION
On record delete only base record was deleted from paged blob storage. In case record was bigger then 2k bytes, some or most fields were stored separately using Toast functionality. DeleteRecs did not go over toasted fields and delete them, trapping most of the used space and not releasing that space for new records.

Also added tests for BlobBs and PgBlobBs, which show that on their level there is no disk leakage when deleting and adding new blogs. In case of BlobBs as long as distribution of sizes remains the same, little space is lost. In case of PgBlobBs, frequent deletes and additions actually improve the percentage of useful space.

PR also contains some fixes needed by latest version of clang to compile without warnings.